### PR TITLE
update AnalyzerCore::WriteHist()

### DIFF
--- a/Analyzers/src/AnalyzerCore.C
+++ b/Analyzers/src/AnalyzerCore.C
@@ -1660,10 +1660,26 @@ void AnalyzerCore::WriteHist(){
 
   outfile->cd();
   for(std::map< TString, TH1D* >::iterator mapit = maphist_TH1D.begin(); mapit!=maphist_TH1D.end(); mapit++){
-    mapit->second->Write();
+    TString this_fullname=mapit->second->GetName();
+    TString this_name=this_fullname(this_fullname.Last('/')+1,this_fullname.Length());
+    TString this_suffix=this_fullname(0,this_fullname.Last('/'));
+    TDirectory *dir = outfile->GetDirectory(this_suffix);
+    if(!dir){
+      outfile->mkdir(this_suffix);
+    }
+    outfile->cd(this_suffix);
+    mapit->second->Write(this_name);
   }
   for(std::map< TString, TH2D* >::iterator mapit = maphist_TH2D.begin(); mapit!=maphist_TH2D.end(); mapit++){
-    mapit->second->Write();
+    TString this_fullname=mapit->second->GetName();
+    TString this_name=this_fullname(this_fullname.Last('/')+1,this_fullname.Length());
+    TString this_suffix=this_fullname(0,this_fullname.Last('/'));
+    TDirectory *dir = outfile->GetDirectory(this_suffix);
+    if(!dir){
+      outfile->mkdir(this_suffix);
+    }
+    outfile->cd(this_suffix);
+    mapit->second->Write(this_name);
   }
 
   outfile->cd();


### PR DESCRIPTION
CUATION: Only JaeSung should confirm this since this is about AnalyzerCore

I update the "AnalyzerCore::WirteHist" for using TDirectory in TFile with "AnalyzerCore::FillHist". "AnalyzerCore::JSFillHist" also can use TDirectory in TFile. But it makes a warning message to prevent from merging output root files if there are files with same names although they are in different directories.

Usage:
FillHist("aaa/bbb/ccc/hist1",....)
Then, the histogram will be writed as "hist1" in TDirectory "aaa/bbb/ccc/" 
