### PR TITLE
update setup_tmp for kisti. now use home directory not scratch

### DIFF
--- a/setup_tmp.sh
+++ b/setup_tmp.sh
@@ -9,13 +9,14 @@ export SKFlatSEDir="/xrootd/store/user/$USER/SKFlatOutput/"
 
 #### USER INFO ####
 export SKFlatLogEmail=''
-export SKFlatLogWeb=''
-export SKFlatLogWebDir=''
+export SKFlatLogWeb='' # leave if blank if you don't have webpage
+export SKFlatLogWebDir='' # leave if blank if you don't have webpage
 
-if [[ $HOSTNAME == *"ui10.sdfarm.kr"* ]]; then
+if [[ $HOSTNAME == *"ui"*".sdfarm.kr"* ]]; then
+
   echo "Working on KISTI"
-  export SKFlatRunlogDir="/cms/scratch/$USER/SKFlatRunlog/"
-  export SKFlatOutputDir="/cms/scratch/$USER/SKFlatOutput/"
+  export SKFlatRunlogDir="/cms/ldap_home/$USER/SKFlatRunlog/"
+  export SKFlatOutputDir="/cms/ldap_home/$USER/SKFlatOutput/"
   export DATA_DIR=data/$SKFlatV
 
   export CMS_PATH=/cvmfs/cms.cern.ch
@@ -26,20 +27,6 @@ if [[ $HOSTNAME == *"ui10.sdfarm.kr"* ]]; then
   cd -
   source /cvmfs/cms.cern.ch/slc6_amd64_gcc630/cms/cmssw/CMSSW_9_4_9_cand2/external/slc6_amd64_gcc630/bin/thisroot.sh
 
-elif [[ $HOSTNAME == *"ui20.sdfarm.kr"* ]]; then
-  echo "Working on KISTI ui20"
-  export SKFlatRunlogDir="/cms/scratch/$USER/SKFlatRunlog/"
-  export SKFlatOutputDir="/cms/scratch/$USER/SKFlatOutput/"
-  export DATA_DIR=data/$SKFlatV
-    
-  export CMS_PATH=/cvmfs/cms.cern.ch
-  source $CMS_PATH/cmsset_default.sh
-  export SCRAM_ARCH=slc6_amd64_gcc630
-  cd /cvmfs/cms.cern.ch/slc6_amd64_gcc630/cms/cmssw/CMSSW_9_4_9_cand2/src/
-  eval `scramv1 runtime -sh`
-  cd -
-  source /cvmfs/cms.cern.ch/slc6_amd64_gcc630/cms/cmssw/CMSSW_9_4_9_cand2/external/slc6_amd64_gcc630/bin/thisroot.sh
-    
 elif [[ $HOSTNAME == *"cms.snu.ac.kr"* ]]; then
 
   echo "Working on 42cluster"


### PR DESCRIPTION
For now, we have to use home directories in KISTI,
becuase any files with "**creation** time > 3 month ago" will be removed under scratch (new KISTI policy).

Please move your working directories, and update with this PR, if you work in KISTI.

I will merge this into master branch tomorrow.