### PR TITLE
correct typo in 2017 electron ID histmap

### DIFF
--- a/data/Run2Legacy_v1/2017/ID/Electron/histmap.txt
+++ b/data/Run2Legacy_v1/2017/ID/Electron/histmap.txt
@@ -4,4 +4,4 @@ ID	SF	passMediumID	2017_ElectronMedium.root	EGamma_SF2D	TH2F
 ID	SF	passHEEPID_Barrel	HEEP_SF.root	SF_Et_Barrel	TGraphAsymmErrors
 ID	SF	passHEEPID_Endcap	HEEP_SF.root	SF_Et_Endcap	TGraphAsymmErrors
 RECO	SF	ptgt20	egammaEffi.txt_EGM2D.root	EGamma_SF2D	TH2F
-RECO	SF	ptlt20	egammaEffi.txt_EGM2D_low.root	EGamma_SF2	TH2F
+RECO	SF	ptlt20	egammaEffi.txt_EGM2D_low.root	EGamma_SF2D	TH2F

--- a/data/v949cand2_2/2017/ID/Electron/histmap.txt
+++ b/data/v949cand2_2/2017/ID/Electron/histmap.txt
@@ -4,4 +4,4 @@ ID	SF	passMediumID	egammaEffi.txt_EGM2D_runBCDEF_passingMedium94X.root	EGamma_SF
 ID	SF	passHEEPID_Barrel	HEEP_SF.root	SF_Et_Barrel	TGraphAsymmErrors
 ID	SF	passHEEPID_Endcap	HEEP_SF.root	SF_Et_Endcap	TGraphAsymmErrors
 RECO	SF	ptgt20	egammaEffi.txt_EGM2D_runBCDEF_passingRECO.root	EGamma_SF2D	TH2F
-RECO	SF	ptlt20	egammaEffi.txt_EGM2D_runBCDEF_passingRECO_lowEt.root	EGamma_SF2	TH2FD
+RECO	SF	ptlt20	egammaEffi.txt_EGM2D_runBCDEF_passingRECO_lowEt.root	EGamma_SF2D	TH2F


### PR DESCRIPTION
correct typo in 2017 electron ID histmap