### PR TITLE
update on PU reweight

### DIFF
--- a/Analyzers/include/AnalyzerCore.h
+++ b/Analyzers/include/AnalyzerCore.h
@@ -119,6 +119,9 @@ public:
   //==== Prefire
   double GetPrefireWeight(int sys);
 
+  //==== PU Reweight
+  double GetPileUpWeight(int N_vtx, int syst);
+
   //==== Functions
 
   bool IsOnZ(double m, double width);

--- a/Analyzers/include/MCCorrection.h
+++ b/Analyzers/include/MCCorrection.h
@@ -51,7 +51,7 @@ public:
   double GetPrefireWeight(std::vector<Photon> photons, std::vector<Jet> jets, int sys);
 
   std::map< TString, TH1D* > map_hist_pileup;
-  double GetPileUpWeightAsSampleName(int N_vtx, int syst);
+  double GetPileUpWeightBySampleName(int N_vtx, int syst);
   double GetPileUpWeight(int N_vtx, int syst);
 
 };

--- a/Analyzers/src/AnalyzerCore.C
+++ b/Analyzers/src/AnalyzerCore.C
@@ -785,6 +785,31 @@ double AnalyzerCore::GetPrefireWeight(int sys){
 
 }
 
+double AnalyzerCore::GetPileUpWeight(int N_vtx, int syst){
+
+  if(IsDATA) return 1.;
+  else{
+
+    if(DataYear==2016){
+      return mcCorr.GetPileUpWeight(N_vtx, syst);
+    }
+    else if(DataYear==2017){
+      return mcCorr.GetPileUpWeightBySampleName(N_vtx, syst);
+    }
+    else if(DataYear==2018){
+      //==== TODO 2018 not yet added
+      return 1.;
+    }
+    else{
+      cout << "[AnalyzerCore::GetPileUpWeight] Wrong year : " << DataYear << endl;
+      exit(EXIT_FAILURE);
+      return 1.;
+    }
+
+  }
+
+}
+
 bool AnalyzerCore::IsOnZ(double m, double width){
   if( fabs(m-M_Z) < width ) return true;
   else return false;

--- a/Analyzers/src/MCCorrection.C
+++ b/Analyzers/src/MCCorrection.C
@@ -525,7 +525,7 @@ double MCCorrection::GetPrefireWeight(std::vector<Photon> photons, std::vector<J
 }
 
 
-double MCCorrection::GetPileUpWeightAsSampleName(int N_vtx, int syst){
+double MCCorrection::GetPileUpWeightBySampleName(int N_vtx, int syst){
   
   int this_bin = N_vtx+1;
   if(N_vtx >= 100) this_bin=100;
@@ -541,13 +541,13 @@ double MCCorrection::GetPileUpWeightAsSampleName(int N_vtx, int syst){
     this_histname += "_sig_up_pileup";
   }
   else{
-    cout << "[MCCorrection::GetPileUpWeightAsSampleName] syst should be 0, -1, or +1" << endl;
+    cout << "[MCCorrection::GetPileUpWeightBySampleName] syst should be 0, -1, or +1" << endl;
     exit(EXIT_FAILURE);
   }
 
   TH1D *this_hist = map_hist_pileup[this_histname];
   if(!this_hist){
-    cout << "[MCCorrection::GetPileUpWeightAsSampleName] No " << this_histname << endl;
+    cout << "[MCCorrection::GetPileUpWeightBySampleName] No " << this_histname << endl;
     exit(EXIT_FAILURE);
   }
 
@@ -571,13 +571,13 @@ double MCCorrection::GetPileUpWeight(int N_vtx, int syst){
     this_histname += "_sig_up_pileup";
   }
   else{
-    cout << "[MCCorrection::GetPileUpWeightAsSampleName] syst should be 0, -1, or +1" << endl;
+    cout << "[MCCorrection::GetPileUpWeightBySampleName] syst should be 0, -1, or +1" << endl;
     exit(EXIT_FAILURE);
   }
 
   TH1D *this_hist = map_hist_pileup[this_histname];
   if(!this_hist){
-    cout << "[MCCorrection::GetPileUpWeightAsSampleName] No " << this_histname << endl;
+    cout << "[MCCorrection::GetPileUpWeightBySampleName] No " << this_histname << endl;
     exit(EXIT_FAILURE);
   }
 


### PR DESCRIPTION
Some updates on PUReweight

1. MCCorrection::GetPileUpWeight**As**SampleName -> MCCorrection::GetPileUpWeight**By**SampleName
2. Create a general PU reweighting function in AnalyzerCore (AnalyzerCore::GetPileUpWeight) which treats DataYear automatically