### PR TITLE
modifying finish point to prevent from hadding before WriteHist

### DIFF
--- a/Analyzers/src/SKFlatNtuple.C
+++ b/Analyzers/src/SKFlatNtuple.C
@@ -36,7 +36,7 @@ void SKFlatNtuple::Loop(){
 
   }
 
-  cout << "[SKFlatNtuple::Loop] JOB FINISHED " << printcurrunttime() << endl;
+  cout << "[SKFlatNtuple::Loop] LOOP END " << printcurrunttime() << endl;
 
 }
 
@@ -60,6 +60,7 @@ SKFlatNtuple::~SKFlatNtuple()
 {
   if (!fChain) return;
   delete fChain->GetCurrentFile();
+  cout << "[SKFlatNtuple::~SKFlatNtuple] JOB FINISHED " << printcurrunttime() << endl;
 }
 
 Int_t SKFlatNtuple::GetEntry(Long64_t entry)

--- a/python/CheckJobStatus.py
+++ b/python/CheckJobStatus.py
@@ -124,7 +124,7 @@ def CheckJobStatus(logfiledir, cycle, jobnumber, hostname):
         break
 
     # [SKFlatNtuple::Loop] JOB FINISHED 2018-12-06 04:10:37
-    line_JobFinished = LASTLINE.replace("[SKFlatNtuple::Loop] JOB FINISHED ","")
+    line_JobFinished = LASTLINE.replace("[SKFlatNtuple::~SKFlatNtuple] JOB FINISHED ","")
     EventDone = GetEventDone(ForTimeEst)
     return "FINISHED"+"\tEVDONE:"+EventDone+"\t"+line_JobStart+"\t"+line_JobFinished
 


### PR DESCRIPTION
I experienced 'hadd' start before WriteHist() finished, which result in incomplete output file.
This can be a problem when there are so many histograms that WriteHist() takes long time.

This is because "JOB FINISHED" is printed just after event loops end.
So, I changed few lines.