### PR TITLE
add an option for test run with only some part of events

### DIFF
--- a/python/SKFlat.py
+++ b/python/SKFlat.py
@@ -21,6 +21,7 @@ parser.add_argument('-y', dest='Year', default="2017")
 parser.add_argument('--skim', dest='Skim', default="")
 parser.add_argument('--no_exec', action='store_true')
 parser.add_argument('--userflags', dest='Userflags', default="")
+parser.add_argument('--reduction', dest='Reduction', default=1, type=float)
 args = parser.parse_args()
 
 ## make userflags as a list
@@ -513,6 +514,9 @@ void {2}(){{
         out.write('  m.SetOutfilePath("hists.root");\n')
       else:
         out.write('  m.SetOutfilePath("'+thisjob_dir+'/hists.root");\n')
+
+    if args.Reduction>1:
+      out.write('  m.MaxEvent=m.fChain->GetEntries()/'+str(args.Reduction)+';\n')
 
     out.write('  m.Init();'+'\n')
     if not IsSkimTree:


### PR DESCRIPTION
I think it will be good to have an option for test run with only some fraction of total events.

SKFlat.py --reduction 100 .... will run with about 1/100 of total events.

I tested it by ExampleRun with DYJets.