### PR TITLE
MCCorrection TFiles closed properly

### DIFF
--- a/AnalyzerTools/include/MCCorrection.h
+++ b/AnalyzerTools/include/MCCorrection.h
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <sstream>
 
+#include "TROOT.h"
 #include "TFile.h"
 #include "TString.h"
 #include "TH1D.h"
@@ -27,6 +28,7 @@ public:
   MCCorrection();
   ~MCCorrection();
 
+  TDirectory *histDir;
   void ReadHistograms();
 
   TString MCSample;

--- a/Analyzers/include/AnalyzerCore.h
+++ b/Analyzers/include/AnalyzerCore.h
@@ -231,7 +231,7 @@ public:
   void FillJetPlots(std::vector<Jet> jets, std::vector<FatJet> fatjets, TString this_region, double weight);
 
   //==== Output rootfile
-
+  void SwitchToTempDir();
   TFile *outfile;
   void SetOutfilePath(TString outname);
 

--- a/Analyzers/src/AnalyzerCore.C
+++ b/Analyzers/src/AnalyzerCore.C
@@ -42,6 +42,28 @@ AnalyzerCore::~AnalyzerCore(){
 
 }
 
+//==== Attach the historams to ai different direcotry, not outfile
+//==== We will write these histograms in WriteHist() to outfile
+void AnalyzerCore::SwitchToTempDir(){
+
+  gROOT->cd();
+  TDirectory *tempDir = NULL;
+  int counter = 0;
+  while (!tempDir) {
+    //==== First, let's find a directory name that doesn't exist yet
+    std::stringstream dirname;
+    dirname << "AnalyzerCore" << counter;
+    if (gROOT->GetDirectory((dirname.str()).c_str())) {
+      ++counter;
+      continue;
+    }
+    //==== Let's try to make this directory
+    tempDir = gROOT->mkdir((dirname.str()).c_str());
+  }
+  tempDir->cd();
+
+}
+
 void AnalyzerCore::SetOutfilePath(TString outname){
   outfile = new TFile(outname,"RECREATE");
 };
@@ -1228,7 +1250,7 @@ void AnalyzerCore::PrintGen(std::vector<Gen> gens){
   cout << "===========================================================" << endl;
   cout << "RunNumber:EventNumber = " << run << ":" << event << endl;
   cout << "index\tPID\tStatus\tMIdx\tMPID\tStart\tPt\tEta\tPhi\tM" << endl;
-  for(unsigned int i=0; i<gens.size(); i++){
+  for(unsigned int i=2; i<gens.size(); i++){
     Gen gen = gens.at(i);
     vector<int> history = TrackGenSelfHistory(gen, gens);
     cout << i << "\t" << gen.PID() << "\t" << gen.Status() << "\t" << gen.MotherIndex() << "\t" << gens.at(gen.MotherIndex()).PID()<< "\t" << history[0] << "\t";
@@ -1863,6 +1885,7 @@ void AnalyzerCore::WriteHist(){
     }
     outfile->cd(this_suffix);
     mapit->second->Write(this_name);
+    outfile->cd();
   }
   for(std::map< TString, TH2D* >::iterator mapit = maphist_TH2D.begin(); mapit!=maphist_TH2D.end(); mapit++){
     TString this_fullname=mapit->second->GetName();
@@ -1874,6 +1897,7 @@ void AnalyzerCore::WriteHist(){
     }
     outfile->cd(this_suffix);
     mapit->second->Write(this_name);
+    outfile->cd();
   }
 
   outfile->cd();

--- a/python/SKFlat.py
+++ b/python/SKFlat.py
@@ -517,15 +517,16 @@ void {2}(){{
     if args.Reduction>1:
       out.write('  m.MaxEvent=m.fChain->GetEntries()/'+str(args.Reduction)+';\n')
 
-    out.write('  m.Init();'+'\n')
-    if not IsSkimTree:
-      out.write('  m.initializeAnalyzerTools();'+'\n')
-    print>>out,'''  m.initializeAnalyzer();
+    print>>out,'''  m.Init();
+  m.initializeAnalyzerTools();
+  m.initializeAnalyzer();
+  m.SwitchToTempDir();
   m.Loop();
 
   m.WriteHist();
 
 }'''
+
     out.close()
 
     if IsTAMSA1:

--- a/setup_tmp.sh
+++ b/setup_tmp.sh
@@ -1,7 +1,7 @@
 export SKFlat_WD=`pwd`
 export SKFlat_LIB_PATH=$SKFlat_WD/lib/
 mkdir -p $SKFlat_LIB_PATH
-mkdir -p tar/
+mkdir -p $SKFlat_WD/tar
 
 export SKFlatV="Run2Legacy_v1"
 mkdir -p $SKFlat_WD/data/$SKFlatV
@@ -12,61 +12,42 @@ export SKFlatLogEmail=''
 export SKFlatLogWeb='' # leave if blank if you don't have webpage
 export SKFlatLogWebDir='' # leave if blank if you don't have webpage
 
+#### use cvmfs for root ####
+export CMS_PATH=/cvmfs/cms.cern.ch
+source $CMS_PATH/cmsset_default.sh
+export SCRAM_ARCH=slc6_amd64_gcc700
+export cmsswrel='cmssw-patch/CMSSW_10_4_0_patch1'
+cd /cvmfs/cms.cern.ch/$SCRAM_ARCH/cms/$cmsswrel/src
+echo "@@@@ SCRAM_ARCH = "$SCRAM_ARCH
+echo "@@@@ cmsswrel = "$cmsswrel
+echo "@@@@ scram..."
+eval `scramv1 runtime -sh`
+cd -
+source /cvmfs/cms.cern.ch/$SCRAM_ARCH/cms/$cmsswrel/external/$SCRAM_ARCH/bin/thisroot.sh
+
 if [[ $HOSTNAME == *"ui"*".sdfarm.kr"* ]]; then
 
-  echo "Working on KISTI"
+  echo "@@@@ Working on KISTI"
   export SKFlatRunlogDir="/cms/ldap_home/$USER/SKFlatRunlog/"
   export SKFlatOutputDir="/cms/ldap_home/$USER/SKFlatOutput/"
 
-  export CMS_PATH=/cvmfs/cms.cern.ch
-  source $CMS_PATH/cmsset_default.sh
-  export SCRAM_ARCH=slc6_amd64_gcc630
-  cd /cvmfs/cms.cern.ch/slc6_amd64_gcc630/cms/cmssw/CMSSW_9_4_9_cand2/src/
-  eval `scramv1 runtime -sh`
-  cd -
-  source /cvmfs/cms.cern.ch/slc6_amd64_gcc630/cms/cmssw/CMSSW_9_4_9_cand2/external/slc6_amd64_gcc630/bin/thisroot.sh
-
 elif [[ $HOSTNAME == *"cms.snu.ac.kr"* ]]; then
 
-  echo "Working on tamsa1"
+  echo "@@@@ Working on tamsa1"
   export SKFlatRunlogDir="/data7/Users/$USER/SKFlatRunlog/"
   export SKFlatOutputDir="/data7/Users/$USER/SKFlatOutput/"
-
-  export CMS_PATH=/cvmfs/cms.cern.ch
-  source $CMS_PATH/cmsset_default.sh
-  export SCRAM_ARCH=slc6_amd64_gcc630
-  cd /cvmfs/cms.cern.ch/slc6_amd64_gcc630/cms/cmssw/CMSSW_9_4_9_cand2/src/
-  eval `scramv1 runtime -sh`
-  cd -
-  source /cvmfs/cms.cern.ch/slc6_amd64_gcc630/cms/cmssw/CMSSW_9_4_9_cand2/external/slc6_amd64_gcc630/bin/thisroot.sh
 
 elif [[ $HOSTNAME == *"tamsa2"* ]]; then
 
-  echo "Working on tamsa2"
+  echo "@@@@ Working on tamsa2"
   export SKFlatRunlogDir="/data7/Users/$USER/SKFlatRunlog/"
   export SKFlatOutputDir="/data7/Users/$USER/SKFlatOutput/"
 
-  export CMS_PATH=/cvmfs/cms.cern.ch
-  source $CMS_PATH/cmsset_default.sh
-  export SCRAM_ARCH=slc7_amd64_gcc630
-  cd /cvmfs/cms.cern.ch/slc7_amd64_gcc630/cms/cmssw/CMSSW_9_4_9/src/
-  eval `scramv1 runtime -sh`
-  cd -
-  source /cvmfs/cms.cern.ch/slc7_amd64_gcc630/cms/cmssw/CMSSW_9_4_9/external/slc7_amd64_gcc630/bin/thisroot.sh
-
 elif [[ $HOSTNAME == *"knu"* ]]; then
 
-  echo "Working on KNU"
+  echo "@@@@ Working on KNU"
   export SKFlatRunlogDir="/u/user/$USER/scratch/SKFlatRunlog/"
   export SKFlatOutputDir="/u/user/$USER/scratch/SKFlatOutput/"
-
-  export CMS_PATH=/cvmfs/cms.cern.ch
-  source $CMS_PATH/cmsset_default.sh
-  export SCRAM_ARCH=slc6_amd64_gcc630
-  cd /cvmfs/cms.cern.ch/slc6_amd64_gcc630/cms/cmssw/CMSSW_9_4_9_cand2/src/
-  eval `scramv1 runtime -sh`
-  cd -
-  source /cvmfs/cms.cern.ch/slc6_amd64_gcc630/cms/cmssw/CMSSW_9_4_9_cand2/external/slc6_amd64_gcc630/bin/thisroot.sh
 
 fi
 


### PR DESCRIPTION
ROOT always attaches the new object s(e.g., histogram obtained with Get() functions) to the currently opened file. If the file is closed, then the object memory is set free.

Before, TFile opened in MCCorrection::ReadHistograms() were not closed due to this reason.

Since CATAnalyzer, to prevent this, we created a new TDirectory and clone the histograms here,
and close the TFile safely.

I use this in our MCCorrection class.


