### PR TITLE
Update/generalised endpoint

### DIFF
--- a/AnalyzerTools/include/AnalyzerTools_LinkDef.h
+++ b/AnalyzerTools/include/AnalyzerTools_LinkDef.h
@@ -11,6 +11,7 @@
 #pragma link C++ class MCCorrection+;
 #pragma link C++ class LHAPDFHandler+;
 #pragma link C++ class PDFReweight+;
+#pragma link C++ class GeneralizedEndpoint+;
 #pragma link C++ class BTagSFUtil+;
 
 #endif

--- a/AnalyzerTools/include/GeneralizedEndpoint.h
+++ b/AnalyzerTools/include/GeneralizedEndpoint.h
@@ -1,0 +1,27 @@
+#ifndef GeneralizedEndpoint_h
+#define GeneralizedEndpoint_h
+
+#include <iostream>
+#include <map>
+
+using namespace std;
+
+struct ScaledPts {
+  double ScaledPt, ScaeldPt_Up, ScaeldPt_Down;
+};
+
+class GeneralizedEndpoint{
+
+public:
+  GeneralizedEndpoint();
+  virtual ~GeneralizedEndpoint();
+
+  ScaledPts GeneralizedEndpointPt(float MuonPt, int MuonCharge, float MuonEta, float MuonPhi, int seed);
+
+private:
+  std::map<int,std::map<int,float> > _Correction;
+  std::map<int,std::map<int,float> > _CorrectionError;   
+
+};
+
+#endif

--- a/AnalyzerTools/include/GeneralizedEndpoint.h
+++ b/AnalyzerTools/include/GeneralizedEndpoint.h
@@ -4,6 +4,9 @@
 #include <iostream>
 #include <map>
 
+//==== https://twiki.cern.ch/twiki/bin/viewauth/CMS/MuonReferenceSelectionAndCalibrationsRun2
+//==== https://github.com/cms-analysis/SUSYBSMAnalysis-Zprime2muAnalysis/blob/mini-AOD/src/GeneralizedEndpoint.cc
+
 using namespace std;
 
 struct ScaledPts {

--- a/AnalyzerTools/src/GeneralizedEndpoint.C
+++ b/AnalyzerTools/src/GeneralizedEndpoint.C
@@ -1,0 +1,132 @@
+#include "GeneralizedEndpoint.h"
+#include <iostream>
+#include "TRandom.h"
+#include <math.h>
+using std::cout;
+using std::cerr;
+using std::endl;
+
+GeneralizedEndpoint::GeneralizedEndpoint(){
+  //Corrections from 2D matrix in MuonPOG presentation in c/TeV.
+  //[-2.4, -2.1]
+  _Correction[0][0] = -0.388122; _CorrectionError[0][0] = 0.045881; //-180,-60
+  _Correction[0][1] =  0.376061; _CorrectionError[0][1] = 0.090062; //-60,60
+  _Correction[0][2] =  -0.153950; _CorrectionError[0][2] = 0.063053; //60,180
+  //[-2.1, -1.2]                                                                                           
+  _Correction[1][0] =  -0.039346; _CorrectionError[1][0] = 0.031655;
+  _Correction[1][1] =  0.041069;  _CorrectionError[1][1] = 0.030070;
+  _Correction[1][2] =  -0.113320; _CorrectionError[1][2] = 0.028683;
+  //[-1.2, 0.]
+  _Correction[2][0] =  0.0;      _CorrectionError[2][0] = 0.025;
+  _Correction[2][1] =  0.0;      _CorrectionError[2][1] = 0.025;
+  _Correction[2][2] =  0.0;      _CorrectionError[2][2] = 0.025;
+  //[-0., 1.2]
+  _Correction[3][0] =  0.0;      _CorrectionError[3][0] = 0.025;
+  _Correction[3][1] =  0.0;      _CorrectionError[3][1] = 0.025;
+  _Correction[3][2] =  0.0;      _CorrectionError[3][2] = 0.025;
+  //[1.2, 2.1]
+  _Correction[4][0] =  0.005114; _CorrectionError[4][0] = 0.033115;
+  _Correction[4][1] =  0.035573; _CorrectionError[4][1] = 0.038574;
+  _Correction[4][2] =  0.070002; _CorrectionError[4][2] = 0.035002;
+  //[2.1, 2.4]
+  _Correction[5][0] =  -0.235470; _CorrectionError[5][0] = 0.077534;
+  _Correction[5][1] =  -0.122719; _CorrectionError[5][1] = 0.061283;
+  _Correction[5][2] =  0.091502;  _CorrectionError[5][2] = 0.074502;
+
+
+};
+
+GeneralizedEndpoint::~GeneralizedEndpoint()
+{
+};
+
+ScaledPts GeneralizedEndpoint::GeneralizedEndpointPt(float MuonPt, int MuonCharge, float MuonEta, float MuonPhi, int seed){
+
+  ScaledPts out;
+  out.ScaledPt = MuonPt;
+  out.ScaeldPt_Up = MuonPt;
+  out.ScaeldPt_Down = MuonPt;
+
+  //Check the input format.
+  if (fabs(MuonEta)>2.4) {
+    cerr<<"ERROR: MuonEta = "<< MuonEta << ", outisde valide range = [-2.4,2.4] "<<endl;
+    return out;
+  }
+  if (fabs(MuonPhi)>180) {
+    cerr<<"ERROR: MuonPhi = "<< MuonPhi << ", outisde valide range = [-180,180] "<<endl;
+    return out;
+  }
+  if (MuonCharge != 1 && MuonCharge != -1) {
+    cerr<<"ERROR: Invalide Muon Charge = "<< MuonCharge << endl;
+    return out;
+  }
+
+  // Eta Binning
+  unsigned int etaBINS = 6;
+  unsigned int kEtaBin = etaBINS;
+  double EtaBin[etaBINS+1];
+  EtaBin[0]=-2.4; EtaBin[1]=-2.1; EtaBin[2]=-1.2; EtaBin[3]=0.;
+  EtaBin[4]=1.2; EtaBin[5]=2.1; EtaBin[6]=2.4;  
+
+  // Phi Binning.
+  unsigned int phiBINS =3;
+  unsigned int kPhiBin = phiBINS;
+  double PhiBin[phiBINS+1];
+  PhiBin[0]=-180.; PhiBin[1]=-60.; PhiBin[2]=60.; PhiBin[3]=180.;
+  
+  for (unsigned int kbin=0; kbin<=etaBINS; ++kbin) {
+    if (MuonEta<EtaBin[kbin+1]) {
+      kEtaBin = kbin;
+      break;
+    }
+  }
+
+  for (unsigned int kbin=0; kbin<=phiBINS; ++kbin) {
+    if (MuonPhi<PhiBin[kbin+1]) {
+      kPhiBin = kbin;
+      break;
+    }
+  }
+
+  float KappaBias=_Correction[kEtaBin][kPhiBin];
+  float KappaBiasError=_CorrectionError[kEtaBin][kPhiBin];
+  
+  float rnd = KappaBias+99*KappaBiasError;
+  gRandom->SetSeed(seed);
+  while (abs(KappaBias-rnd) > KappaBiasError)
+    rnd = gRandom->Gaus(KappaBias,KappaBiasError);
+
+  KappaBias = rnd;
+  // if ((KappaBias-KappaBiasError)/KappaBias > 0.70) return MuonPt;
+  //  if (abs(KappaBiasError/KappaBias) > 0.70) return MuonPt; // ignore the bias if the error on the estimation is too big... 
+  
+  MuonPt = MuonPt/1000.; //GeV to TeV.
+  MuonPt = MuonCharge*fabs(MuonPt); //Signed Pt.
+  MuonPt = 1/MuonPt; //Convert to Curvature.
+  MuonPt = MuonPt + KappaBias; //Apply the bias.
+
+  double MuonPt_Central = MuonPt + KappaBias;
+  double MuonPt_Up = MuonPt + KappaBias + KappaBiasError;
+  double MuonPt_Down = MuonPt + KappaBias - KappaBiasError;
+
+  if (fabs(MuonPt_Central) < 0.14) MuonPt_Central = KappaBiasError; //To avoid a division by set the curvature to its error if after the correction the pt is larger than 7 TeV.
+  MuonPt_Central = 1/MuonPt_Central;//Return to Pt.
+  MuonPt_Central = fabs(MuonPt_Central);//returns unsigned Pt, any possible sign flip due to the curvature is absorbed here.
+  MuonPt_Central = MuonPt_Central*1000.;//Return to Pt in GeV.
+
+  if (fabs(MuonPt_Up) < 0.14) MuonPt_Up = KappaBiasError; //To avoid a division by set the curvature to its error if after the correction the pt is larger than 7 TeV.
+  MuonPt_Up = 1/MuonPt_Up;//Return to Pt.
+  MuonPt_Up = fabs(MuonPt_Up);//returns unsigned Pt, any possible sign flip due to the curvature is absorbed here.
+  MuonPt_Up = MuonPt_Up*1000.;//Return to Pt in GeV.
+
+  if (fabs(MuonPt_Down) < 0.14) MuonPt_Down = KappaBiasError; //To avoid a division by set the curvature to its error if after the correction the pt is larger than 7 TeV.
+  MuonPt_Down = 1/MuonPt_Down;//Return to Pt.
+  MuonPt_Down = fabs(MuonPt_Down);//returns unsigned Pt, any possible sign flip due to the curvature is absorbed here.
+  MuonPt_Down = MuonPt_Down*1000.;//Return to Pt in GeV.
+
+  out.ScaledPt = MuonPt_Central;
+  out.ScaeldPt_Up = MuonPt_Up;
+  out.ScaeldPt_Down = MuonPt_Down;
+
+  return out;
+};

--- a/AnalyzerTools/src/GeneralizedEndpoint.C
+++ b/AnalyzerTools/src/GeneralizedEndpoint.C
@@ -49,15 +49,15 @@ ScaledPts GeneralizedEndpoint::GeneralizedEndpointPt(float MuonPt, int MuonCharg
 
   //Check the input format.
   if (fabs(MuonEta)>2.4) {
-    cerr<<"ERROR: MuonEta = "<< MuonEta << ", outisde valide range = [-2.4,2.4] "<<endl;
+    //cerr<<"ERROR: MuonEta = "<< MuonEta << ", outisde valide range = [-2.4,2.4] "<<endl;
     return out;
   }
   if (fabs(MuonPhi)>180) {
-    cerr<<"ERROR: MuonPhi = "<< MuonPhi << ", outisde valide range = [-180,180] "<<endl;
+    //cerr<<"ERROR: MuonPhi = "<< MuonPhi << ", outisde valide range = [-180,180] "<<endl;
     return out;
   }
   if (MuonCharge != 1 && MuonCharge != -1) {
-    cerr<<"ERROR: Invalide Muon Charge = "<< MuonCharge << endl;
+    //cerr<<"ERROR: Invalide Muon Charge = "<< MuonCharge << endl;
     return out;
   }
 

--- a/Analyzers/include/AnalyzerCore.h
+++ b/Analyzers/include/AnalyzerCore.h
@@ -22,6 +22,7 @@
 #include "FakeBackgroundEstimator.h"
 #include "CFBackgroundEstimator.h"
 #include "BTagSFUtil.h"
+#include "GeneralizedEndpoint.h"
 #include "PDFReweight.h"
 
 #define M_Z 91.1876
@@ -134,6 +135,8 @@ public:
   //==== PU Reweight
   double GetPileUpWeight(int N_pileup, int syst);
 
+  //==== Muon GeneralizedEngpoint momentum scaling
+  GeneralizedEndpoint *muonGE;
 
   //==== Btag setup
   void SetupBTagger(std::vector<Jet::Tagger> taggers, std::vector<Jet::WP> wps, bool setup_systematics, bool period_dependant);

--- a/Analyzers/src/AnalyzerCore.C
+++ b/Analyzers/src/AnalyzerCore.C
@@ -6,6 +6,7 @@ AnalyzerCore::AnalyzerCore(){
   fakeEst = new FakeBackgroundEstimator();
   cfEst = new CFBackgroundEstimator();
   pdfReweight = new PDFReweight();
+  muonGE = new GeneralizedEndpoint();
 
 }
 
@@ -72,14 +73,13 @@ std::vector<Muon> AnalyzerCore::GetAllMuons(){
 
     double rc = muon_roch_sf->at(i);
     double rc_err = muon_roch_sf_up->at(i)-rc;
-    mu.SetMomentumScaleAndError(rc, rc_err);
+    //==== For the Rochester corection, up and down err are the same
+    mu.SetMomentumScaleUpDown( muon_pt->at(i) * (rc+rc_err), muon_pt->at(i) * (rc-rc_err)  );
     mu.SetPtEtaPhiM(muon_pt->at(i)*rc, muon_eta->at(i), muon_phi->at(i), muon_mass->at(i));
 
     //==== TuneP
-    //==== Apply rochester correction for pt<200 GeV
-    double this_tuneP_pt = muon_TuneP_pt->at(i);
-    if(this_tuneP_pt < 200.) this_tuneP_pt *= rc;
-    mu.SetTuneP4(this_tuneP_pt, muon_TuneP_ptError->at(i), muon_TuneP_eta->at(i), muon_TuneP_phi->at(i), muon_TuneP_charge->at(i));
+    //==== Apply scailing later with AnalyzerCore::UseTunePMuon()
+    mu.SetTuneP4(muon_TuneP_pt->at(i), muon_TuneP_ptError->at(i), muon_TuneP_eta->at(i), muon_TuneP_phi->at(i), muon_TuneP_charge->at(i));
 
     mu.SetdXY(muon_dxyVTX->at(i), muon_dxyerrVTX->at(i));
     mu.SetdZ(muon_dzVTX->at(i), muon_dzerrVTX->at(i));
@@ -503,13 +503,66 @@ std::vector<Muon> AnalyzerCore::UseTunePMuon(std::vector<Muon> muons){
     Muon this_muon=muons.at(i);
 
     Particle this_tunep4 = this_muon.TuneP4();
-    this_muon.SetPtEtaPhiM( this_tunep4.Pt(), this_tunep4.Eta(), this_tunep4.Phi(), this_tunep4.M() );
+
+    //==== Momentum scaling
+    //==== 1) if tuneP Pt < 200 -> Rochester
+    //==== 2) if tuneP pt >= 200 -> Generalized Endpoint
+
+    double new_pt, new_pt_up, new_pt_down;
+    if(this_tunep4.Pt()<200){
+
+      //==== 19/03/24 (jskim) : For 99% of the muons, MiniAODPt and TunePPt are same
+      //==== we can just use MiniAODPt * RochesterCorrection, multiplied by (TuneP Pt)/(MiniAODPt)
+      double TunePOverPt = this_tunep4.Pt() / this_muon.MiniAODPt();
+      new_pt      = TunePOverPt * this_muon.Pt(); // this_muon.Pt() = MiniAODPt * RochesterCorrection
+      new_pt_up   = TunePOverPt * this_muon.MomentumShift(+1);
+      new_pt_down = TunePOverPt * this_muon.MomentumShift(-1);
+
+/*
+      cout << "## Rochester ##" << endl;
+      cout << "this_muon.MiniAODPt() = " << this_muon.MiniAODPt() << endl;
+      cout << "this_muon.MiniAODTunePPt() = " << this_muon.MiniAODTunePPt() << endl;
+      cout << "new_pt = " << new_pt << endl;
+      cout << "new_pt_up = " << new_pt_up << endl;
+      cout << "new_pt_down = " << new_pt_down << endl;
+*/
+
+    }
+    else{
+
+      //==== ScaledPts defined in GeneralizedEndpointPt.h ..
+      ScaledPts ptvalues = muonGE->GeneralizedEndpointPt(this_tunep4.Pt(), this_tunep4.Charge(), this_tunep4.Eta(), this_tunep4.Phi()*180./M_PI, event);
+      new_pt = ptvalues.ScaledPt;
+      //==== Mode == 1 : Kappa up
+      //==== Mode == 2 : Kappa down
+      new_pt_up = ptvalues.ScaeldPt_Up;
+      new_pt_down = ptvalues.ScaeldPt_Down;
+
+/*
+      cout << "## GeneralizedEndpointPt ##" << endl;
+      cout << "old_pt = " << this_tunep4.Pt() << endl;
+      cout << "new_pt = " << new_pt << endl;
+      cout << "new_pt_up = " << new_pt_up << endl;
+      cout << "new_pt_down = " << new_pt_down << endl;
+*/
+
+    }
+
+    //==== Scale the pt
+    this_muon.SetPtEtaPhiM( new_pt, this_tunep4.Eta(), this_tunep4.Phi(), this_tunep4.M() );
+    this_muon.SetMomentumScaleUpDown(new_pt_up,new_pt_down);
     this_muon.SetCharge( this_tunep4.Charge() );
     this_muon.SetMiniAODPt( this_muon.MiniAODTunePPt() );
 
-    //==== TODO If MiniAODTunePPt >= 200, we don't use Rochester correction
-    //==== so let's set rc=1 and rc_err=0
-    if( this_muon.MiniAODTunePPt() >= 200. ) this_muon.SetMomentumScaleAndError(1., 0.);
+/*
+    cout << "@@@@ TuneP @@@@" << endl;
+    cout << "this_muon.Pt() = " << this_muon.Pt() << endl;
+    cout << "this_muon.MiniAODPt() = " << this_muon.MiniAODPt() << endl;
+    cout << "this_muon.MiniAODTunePPt() = " << this_muon.MiniAODTunePPt() << endl;
+    cout << "this_muon.MomentumShift(0) = " << this_muon.MomentumShift(0) << endl;
+    cout << "this_muon.MomentumShift(+1) = " << this_muon.MomentumShift(+1) << endl;
+    cout << "this_muon.MomentumShift(-1) = " << this_muon.MomentumShift(-1) << endl;
+*/
 
     out.push_back(this_muon);
   }
@@ -647,7 +700,7 @@ std::vector<Muon> AnalyzerCore::ScaleMuons(std::vector<Muon> muons, int sys){
   for(unsigned int i=0; i<muons.size(); i++){
     Muon this_muon = muons.at(i);
 
-    //==== TODO When we use TuneP, if MiniAODTunePPt >= 200., we set rc=1 and rc_err=0
+    //==== Even for TuneP muons, MomentumShift() are set correctly from AnalyzerCore::UseTunePMuon()
     //==== So we can just use MomentumShift()
 
     this_muon.SetPtEtaPhiM( this_muon.MomentumShift(sys), this_muon.Eta(), this_muon.Phi(), this_muon.M() );

--- a/DataFormats/include/Muon.h
+++ b/DataFormats/include/Muon.h
@@ -77,13 +77,11 @@ public:
   inline double MiniAODPt() const {return j_MiniAODPt;}
   inline double MiniAODTunePPt() const {return j_MiniAODTunePPt;}
 
-  void SetMomentumScaleAndError(double rc, double rc_err);
-  inline double MomentumScale() const {return j_rc;}
-  inline double MomentumScaleError() const {return j_rc_err;}
+  void SetMomentumScaleUpDown(double pt_up, double pt_down);
   inline double MomentumShift(int s) const {
-    if(s==0) return 1.;
-    else if(s>0) return Pt() * (j_rc + j_rc_err) / j_rc;
-    else         return Pt() * (j_rc - j_rc_err) / j_rc;
+    if(s==0) return Pt();
+    else if(s>0) return j_MomentumScaleUp;
+    else         return j_MomentumScaleDown;
   }
 
   void SetTuneP4(double pt, double pt_err, double eta, double phi, double q);
@@ -102,7 +100,7 @@ private:
   unsigned int j_TypeBit, j_IDBit;
   double j_chi2;
   double j_PFCH04, j_PFNH04, j_PFPH04, j_PU04, j_trkiso;
-  double j_MiniAODPt, j_MiniAODTunePPt, j_rc, j_rc_err, j_MomentumUp, j_MomentumDown;
+  double j_MiniAODPt, j_MiniAODTunePPt, j_MomentumScaleUp, j_MomentumScaleDown;
   Particle j_TuneP4;
   double j_TunePPtError;
 

--- a/DataFormats/src/Muon.C
+++ b/DataFormats/src/Muon.C
@@ -11,8 +11,8 @@ Muon::Muon() : Lepton() {
   j_trkiso = -999.;
   this->SetLeptonFlavour(MUON);
   j_MiniAODPt = -999.;
-  j_rc = -999.;
-  j_rc_err = -999.;
+  j_MomentumScaleUp = -999.;
+  j_MomentumScaleDown = -999.;
   j_TunePPtError = -999.;
 }
 
@@ -70,9 +70,10 @@ void Muon::SetMiniAODPt(double d){
 void Muon::SetMiniAODTunePPt(double d){
   j_MiniAODTunePPt = d;
 }
-void Muon::SetMomentumScaleAndError(double rc, double rc_err){
-  j_rc = rc;
-  j_rc_err = rc_err;
+
+void Muon::SetMomentumScaleUpDown(double pt_up, double pt_down){
+  j_MomentumScaleUp = pt_up;
+  j_MomentumScaleDown = pt_down;
 }
 
 void Muon::SetTuneP4(double pt, double pt_err, double eta, double phi, double q){


### PR DESCRIPTION
Class for Generalized Endpoint method added.

- Now, we don't apply any momentum scale for TuneP Track in AnalyzerCore::GetAllMuons()
- If user wants to use HighPt ID, they must use AnalyzerCore ::UseTunePMuon() to replace muon momentum (and their momentum scale up/down) by TuneP4 * Scaling
   - When TuneP Pt < 200 GeV, apply Rochester correction
   - Otherwise apply Generalized Endpoint scaling

In summary, in the analysis with TuneP muons,

`vector<Muon> muons = UseTunePMuon( GetMuons(<highpt id>, ptmin, etamax) );`
`//==== If you want to scale up,`
`vector<Muon> muons_up = ScaleMuons( muons, +1 );`
`//==== If you want to scale down,`
`vector<Muon> muons_down = ScaleMuons( muons, -1 );`