### PR TITLE
condor submission faster

### DIFF
--- a/python/CheckJobStatus.py
+++ b/python/CheckJobStatus.py
@@ -89,7 +89,7 @@ def CheckJobStatus(logfiledir, cycle, jobnumber, hostname):
 
   IsCycleRan = False
   for l in log_o:
-    if "Processing run" in l:
+    if "Processing " in l:
       IsCycleRan = True
       break
 

--- a/python/SKFlat.py
+++ b/python/SKFlat.py
@@ -50,6 +50,8 @@ USER = os.environ['USER']
 SKFlatLogEmail = os.environ['SKFlatLogEmail']
 SKFlatLogWeb = os.environ['SKFlatLogWeb']
 SKFlatLogWebDir = os.environ['SKFlatLogWebDir']
+SCRAM_ARCH = os.environ['SCRAM_ARCH']
+cmsswrel = os.environ['cmsswrel']
 SKFlat_WD = os.environ['SKFlat_WD']
 SKFlatV = os.environ['SKFlatV']
 SAMPLE_DATA_DIR = SKFlat_WD+'/data/'+SKFlatV+'/'+args.Year+'/Sample/'
@@ -167,32 +169,10 @@ for flag in Userflags:
   MasterJobDir += '__'+flag
 MasterJobDir += '__'+HOSTNAME+'/'
 
-## Condor
-if IsKISTI or IsTAMSA2:
+## Copy libray
 
-  ## If condor, compress files
-
-  cwd = os.getcwd()
-  os.chdir(SKFlat_WD)
-  os.system('make -s CondorTar')
-  os.chdir(cwd)
-
-  ## Copy shared library file
-
-  os.system('mkdir -p '+MasterJobDir)
-
-  os.system('cp '+SKFlat_WD+'/tar/data.tar.gz '+MasterJobDir+'/data.tar.gz')
-  os.system('cp '+SKFlat_WD+'/tar/lib.tar.gz '+MasterJobDir+'/lib.tar.gz')
-  os.system('cp '+SKFlat_WD+'/lib/DataFormats.tar.gz '+MasterJobDir)
-  os.system('cp '+SKFlat_WD+'/lib/AnalyzerTools.tar.gz '+MasterJobDir)
-  os.system('cp '+SKFlat_WD+'/lib/Analyzers.tar.gz '+MasterJobDir)
-
-else:
-
-  ## Else, we only have to copy libray
-
-  os.system('mkdir -p '+MasterJobDir+'/lib/')
-  os.system('cp '+SKFlat_LIB_PATH+'/* '+MasterJobDir+'/lib')
+os.system('mkdir -p '+MasterJobDir+'/lib/')
+os.system('cp '+SKFlat_LIB_PATH+'/* '+MasterJobDir+'/lib')
 
 ## Loop over samples
 
@@ -315,39 +295,24 @@ for InputSample in InputSamples:
       commandsfilename += '__'+flag
     run_commands = open(base_rundir+'/'+commandsfilename+'.sh','w')
     print>>run_commands,'''#!/bin/bash
-SECTION=`printf %03d $1`
+SECTION=`printf $1`
 WORKDIR=`pwd`
-echo "#### Extracting DataFormats ####"
-tar -zxf DataFormats.tar.gz
-echo "####  Extracting AnalyzerTools ####"
-tar -zxf AnalyzerTools.tar.gz
-echo "####  Extracting Analyzers ####"
-tar -zxf Analyzers.tar.gz
-echo "#### Extracting libraries ####"
-tar -zxf lib.tar.gz
-echo "#### Extracting run files ####"
-tar -zxf runFile.tar.gz
-echo "#### Extracting data files ####"
-tar -zxf data.tar.gz
-echo "#### cmsenv ####"
-export CMS_PATH=/cvmfs/cms.cern.ch
-source $CMS_PATH/cmsset_default.sh
-export SCRAM_ARCH=slc6_amd64_gcc700
-cd /cvmfs/cms.cern.ch/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_10_4_0_patch1/src/
-eval `scramv1 runtime -sh`
-cd -
-echo "#### setup root ####"
-source /cvmfs/cms.cern.ch/slc6_amd64_gcc700/cms/cmssw-patch/CMSSW_10_4_0_patch1/external/slc6_amd64_gcc700/bin/thisroot.sh
-
-export SKFlatV="{0}"
-export SKFlat_WD=`pwd`
-export SKFlat_LIB_PATH=$SKFlat_WD/lib/
-export DATA_DIR=$SKFlat_WD/data/$SKFlatV
-export ROOT_INCLUDE_PATH=$ROOT_INCLUDE_PATH:$SKFlat_WD/DataFormats/include/:$SKFlat_WD/Analyzers/include/:$SKFlat_WD/AnalyzerTools/include/
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SKFlat_LIB_PATH
 
 SumNoAuth=999
 Trial=0
+
+#### use cvmfs for root ####
+export CMS_PATH=/cvmfs/cms.cern.ch
+source $CMS_PATH/cmsset_default.sh
+export SCRAM_ARCH={2}
+export cmsswrel='{3}'
+cd /cvmfs/cms.cern.ch/$SCRAM_ARCH/cms/$cmsswrel/src
+echo "@@@@ SCRAM_ARCH = "$SCRAM_ARCH
+echo "@@@@ cmsswrel = "$cmsswrel
+echo "@@@@ scram..."
+eval `scramv1 runtime -sh`
+cd -
+source /cvmfs/cms.cern.ch/$SCRAM_ARCH/cms/$cmsswrel/external/$SCRAM_ARCH/bin/thisroot.sh
 
 while [ "$SumNoAuth" -ne 0 ]; do
 
@@ -356,8 +321,8 @@ while [ "$SumNoAuth" -ne 0 ]; do
   fi
 
   echo "#### running ####"
-  echo "root -l -b -q run_${{SECTION}}.C"
-  root -l -b -q run_${{SECTION}}.C 2> err.log
+  echo "root -l -b -q {1}/run_${{SECTION}}.C"
+  root -l -b -q {1}/run_${{SECTION}}.C 2> err.log
   NoAuthError_Open=`grep "Error in <TNetXNGFile::Open>" err.log -R | wc -l`
   NoAuthError_Close=`grep "Error in <TNetXNGFile::Close>" err.log -R | wc -l`
 
@@ -373,60 +338,58 @@ while [ "$SumNoAuth" -ne 0 ]; do
 done
 
 cat err.log >&2
-'''.format(SKFlatV)
+'''.format(SKFlatV, base_rundir, SCRAM_ARCH, cmsswrel)
     run_commands.close()
 
     submit_command = open(base_rundir+'/submit.jds','w')
     if IsUI10:
-      print>>submit_command,'''executable = {3}.sh
+      print>>submit_command,'''executable = {1}.sh
 universe   = vanilla
 arguments  = $(Process)
 requirements = OpSysMajorVer == 6
 log = condor.log
-getenv     = False
+getenv     = True
 should_transfer_files = YES
 when_to_transfer_output = ON_EXIT
 output = job_$(Process).log
 error = job_$(Process).err
 transfer_input_files = {0}, {1}, {4}, {5}, {6}, {7}
 transfer_output_remaps = "hists.root = output/hists_$(Process).root"
-queue {2}
-'''.format(base_rundir+'/runFile.tar.gz', MasterJobDir+'/lib.tar.gz',str(NJobs), commandsfilename, MasterJobDir+'/data.tar.gz', MasterJobDir+'/Analyzers.tar.gz', MasterJobDir+'/AnalyzerTools.tar.gz', MasterJobDir+'/DataFormats.tar.gz')
+queue {0}
+'''.format(str(NJobs), commandsfilename)
       submit_command.close()
     elif IsUI20:
-      print>>submit_command,'''executable = {3}.sh
+      print>>submit_command,'''executable = {1}.sh
 universe   = vanilla
 requirements = ( HasSingularity == true )
 arguments  = $(Process)
 log = condor.log
-getenv     = False
+getenv     = True
 should_transfer_files = YES
 when_to_transfer_output = ON_EXIT
 output = job_$(Process).log
 error = job_$(Process).err
-transfer_input_files = {0}, {1}, {4}, {5}, {6}, {7}
 accounting_group=group_cms
 +SingularityImage = "/cvmfs/singularity.opensciencegrid.org/opensciencegrid/osgvo-el6:latest"
 +SingularityBind = "/cvmfs, /cms, /share"
 transfer_output_remaps = "hists.root = output/hists_$(Process).root"
-queue {2}
-'''.format(base_rundir+'/runFile.tar.gz', MasterJobDir+'/lib.tar.gz',str(NJobs), commandsfilename, MasterJobDir+'/data.tar.gz', MasterJobDir+'/Analyzers.tar.gz', MasterJobDir+'/AnalyzerTools.tar.gz', MasterJobDir+'/DataFormats.tar.gz')
+queue {0}
+'''.format(str(NJobs), commandsfilename)
       submit_command.close()
     elif IsTAMSA2:
-      print>>submit_command,'''executable = {3}.sh
+      print>>submit_command,'''executable = {1}.sh
 universe   = vanilla
 arguments  = $(Process)
 log = condor.log
-getenv     = False
+getenv     = True
 should_transfer_files = YES
 when_to_transfer_output = ON_EXIT
 output = job_$(Process).log
 error = job_$(Process).err
-transfer_input_files = {0}, {1}, {4}, {5}, {6}, {7}
 accounting_group=group_cms
 transfer_output_remaps = "hists.root = output/hists_$(Process).root"
-queue {2}
-'''.format(base_rundir+'/runFile.tar.gz', MasterJobDir+'/lib.tar.gz',str(NJobs), commandsfilename, MasterJobDir+'/data.tar.gz', MasterJobDir+'/Analyzers.tar.gz', MasterJobDir+'/AnalyzerTools.tar.gz', MasterJobDir+'/DataFormats.tar.gz')
+queue {0}
+'''.format(str(NJobs), commandsfilename)
       submit_command.close()
 
   CheckTotalNFile=0
@@ -444,9 +407,8 @@ queue {2}
     libdir = (MasterJobDir+'/lib').replace('///','/').replace('//','/')+'/'
     runCfileFullPath = ""
     if IsKISTI or IsTAMSA2:
-      libdir = './lib/'
-      runfunctionname = "run_"+str(it_job).zfill(3)
-      runCfileFullPath = base_rundir+'/run_'+str(it_job).zfill(3)+'.C'
+      runfunctionname = "run_"+str(it_job)
+      runCfileFullPath = base_rundir+'/run_'+str(it_job)+'.C'
     else:
       os.system('mkdir -p '+thisjob_dir)
       runCfileFullPath = thisjob_dir+'run.C'
@@ -573,7 +535,6 @@ root -l -b -q run.C 1>stdout.log 2>stderr.log
 
     cwd = os.getcwd()
     os.chdir(base_rundir)
-    os.system('tar -czf runFile.tar.gz run_*.C')
     if not args.no_exec:
       os.system('condor_submit submit.jds')
     os.chdir(cwd)

--- a/python/SKFlat.py
+++ b/python/SKFlat.py
@@ -305,7 +305,7 @@ Trial=0
 export CMS_PATH=/cvmfs/cms.cern.ch
 source $CMS_PATH/cmsset_default.sh
 export SCRAM_ARCH={2}
-export cmsswrel='{3}'
+export cmsswrel={3}
 cd /cvmfs/cms.cern.ch/$SCRAM_ARCH/cms/$cmsswrel/src
 echo "@@@@ SCRAM_ARCH = "$SCRAM_ARCH
 echo "@@@@ cmsswrel = "$cmsswrel
@@ -353,7 +353,6 @@ should_transfer_files = YES
 when_to_transfer_output = ON_EXIT
 output = job_$(Process).log
 error = job_$(Process).err
-transfer_input_files = {0}, {1}, {4}, {5}, {6}, {7}
 transfer_output_remaps = "hists.root = output/hists_$(Process).root"
 queue {0}
 '''.format(str(NJobs), commandsfilename)


### PR DESCRIPTION
When using Condor, we compress all the libraries, data files, and run files, and then send it to the sandbox.

This was done because scratch had some issues in KISTI, so nodes sometimes could not access scratch directories.

However, it looks like this is fixed, and also we use home directory in KISTI.

Condor in TAMSA also can access working directories, so I found no reason to make tar files.

This made the job submission very slow (espcially in TAMSA).

Now this is fixed, and submission is enhanced a lot.

 