### PR TITLE
--FastSim option added; METFilter updated for FastSim; Print setups i…

### DIFF
--- a/Analyzers/include/SKFlatNtuple.h
+++ b/Analyzers/include/SKFlatNtuple.h
@@ -37,6 +37,7 @@ public :
    bool IsDATA;
    TString DataStream;
    TString MCSample;
+   bool IsFastSim;
    int DataYear;
    double xsec, sumW, weight_norm_1invpb;
    vector<TString> Userflags;

--- a/Analyzers/src/AnalyzerCore.C
+++ b/Analyzers/src/AnalyzerCore.C
@@ -828,18 +828,18 @@ std::vector<FatJet> AnalyzerCore::SmearSDMassFatJets(std::vector<FatJet> jets, i
 bool AnalyzerCore::PassMETFilter(){
 
   //==== https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#Moriond_2018
-  //==== TODO If FastSIM, it should be changed
 
   if(!Flag_goodVertices) return false;
-  if(!Flag_globalSuperTightHalo2016Filter) return false;
+  if(!IsFastSim){
+    if(!Flag_globalSuperTightHalo2016Filter) return false;
+  }
   if(!Flag_HBHENoiseFilter) return false;
   if(!Flag_HBHENoiseIsoFilter) return false;
   if(!Flag_EcalDeadCellTriggerPrimitiveFilter) return false;
   if(!Flag_BadPFMuonFilter) return false;
-  if(!Flag_BadChargedCandidateFilter) return false;
+  //if(!Flag_BadChargedCandidateFilter) return false; // TODO 19/05/04 twiki says this is under review, and not recommended
   if(IsDATA && !Flag_eeBadScFilter) return false;
 
-  //TODO Check this
   if(DataYear>=2017){
     if(!Flag_ecalBadCalibReducedMINIAODFilter) return false;
   }

--- a/Analyzers/src/SKFlatNtuple.C
+++ b/Analyzers/src/SKFlatNtuple.C
@@ -14,6 +14,25 @@ void SKFlatNtuple::Loop(){
     nentries = std::min(nentries,MaxEvent);
   }
 
+  //==== Before starting the loop, print setups
+  cout << "[SKFlatNtuple::Loop] MaxEvent = " << MaxEvent << endl;
+  cout << "[SKFlatNtuple::Loop] NSkipEvent = " << NSkipEvent << endl;
+  cout << "[SKFlatNtuple::Loop] LogEvery = " << LogEvery << endl;
+  cout << "[SKFlatNtuple::Loop] IsDATA = " << IsDATA << endl;
+  cout << "[SKFlatNtuple::Loop] DataStream = " << DataStream << endl;
+  cout << "[SKFlatNtuple::Loop] MCSample = " << MCSample << endl;
+  cout << "[SKFlatNtuple::Loop] IsFastSim = " << IsFastSim << endl;
+  cout << "[SKFlatNtuple::Loop] DataYear = " << DataYear << endl;
+  cout << "[SKFlatNtuple::Loop] xsec = " << xsec << endl;
+  cout << "[SKFlatNtuple::Loop] sumW = " << sumW << endl;
+  cout << "[SKFlatNtuple::Loop] weight_norm_1invpb = " << weight_norm_1invpb << endl;
+  cout << "[SKFlatNtuple::Loop] Userflags = {" << endl;
+  for(unsigned int i=0; i<Userflags.size(); i++){
+    cout << "[SKFlatNtuple::Loop]   \"" << Userflags.at(i) << "\"," << endl;
+  }
+  cout << "[SKFlatNtuple::Loop] }" << endl;
+
+
   cout << "[SKFlatNtuple::Loop] Event Loop Started " << printcurrunttime() << endl;
 
   for(Long64_t jentry=0; jentry<nentries;jentry++){
@@ -49,6 +68,7 @@ SKFlatNtuple::SKFlatNtuple(){
   IsDATA = false;
   DataStream = "";
   MCSample = "";
+  IsFastSim = false;
   DataYear = 2017;
   xsec = 1.;
   sumW = 1.;

--- a/python/SKFlat.py
+++ b/python/SKFlat.py
@@ -20,6 +20,7 @@ parser.add_argument('-q', dest='Queue', default="fastq")
 parser.add_argument('-y', dest='Year', default="2017")
 parser.add_argument('--skim', dest='Skim', default="")
 parser.add_argument('--no_exec', action='store_true')
+parser.add_argument('--FastSim', action='store_true')
 parser.add_argument('--userflags', dest='Userflags', default="")
 parser.add_argument('--reduction', dest='Reduction', default=1, type=float)
 args = parser.parse_args()
@@ -448,6 +449,11 @@ void {2}(){{
       out.write('  m.IsDATA = false;\n')
       out.write('  m.xsec = '+str(this_xsec)+';\n')
       out.write('  m.sumW = '+str(this_sumw)+';\n')
+
+      if args.FastSim:
+        out.write('  m.IsFastSim = true;\n')
+      else:
+        out.write('  m.IsFastSim = false;\n')
 
     out.write('  m.DataYear = '+str(args.Year)+';\n')
 


### PR DESCRIPTION
--FastSim option is added.
From [METFilter twiki](https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#Moriond_2018), _Flag_globalSuperTightHalo2016Filter_ should **NOT** be applied for FastSim samples.
If you are running FastSim samples, you **must** use this option to apply METFilter correctly.
Also, _Flag_BadChargedCandidateFilter_ is now **NOT** recommended, and under review.

Also, now we print some basic settings of the analyzer just before we start the event loop.
Logfile now contains more information..
Example is below;

`[SKFlatNtuple::Loop] MaxEvent = -1`
`[SKFlatNtuple::Loop] NSkipEvent = 0`
`[SKFlatNtuple::Loop] LogEvery = 10000`
`[SKFlatNtuple::Loop] IsDATA = 0`
`[SKFlatNtuple::Loop] DataStream = `
`[SKFlatNtuple::Loop] MCSample = ZZ_pythia`
`[SKFlatNtuple::Loop] IsFastSim = 0`
`[SKFlatNtuple::Loop] DataYear = 2016`
`[SKFlatNtuple::Loop] xsec = 16.523`
`[SKFlatNtuple::Loop] sumW = 990064`
`[SKFlatNtuple::Loop] weight_norm_1invpb = 1.66888e-05`
`[SKFlatNtuple::Loop] Userflags = {`
`[SKFlatNtuple::Loop]   "A",`
`[SKFlatNtuple::Loop]   "B",`
`[SKFlatNtuple::Loop]   "C",`
`[SKFlatNtuple::Loop] }`
`[SKFlatNtuple::Loop] Event Loop Started 2019-05-04 07:24:53`
`[SKFlatNtuple::Loop RUNNING] 0/145184 (0 %) @ 2019-05-04 07:24:53`
 