### PR TITLE
Faster GetEffLumi

### DIFF
--- a/Analyzers/include/GetEffLumi.h
+++ b/Analyzers/include/GetEffLumi.h
@@ -7,6 +7,7 @@ class GetEffLumi : public AnalyzerCore {
 
 public:
 
+  void initializeAnalyzer();
   void executeEvent();
 
 };

--- a/Analyzers/src/GetEffLumi.C
+++ b/Analyzers/src/GetEffLumi.C
@@ -1,12 +1,19 @@
 #include "GetEffLumi.h"
 
+void GetEffLumi::initializeAnalyzer(){
+  fChain->SetBranchStatus("*",0);
+  fChain->SetBranchStatus("gen_weight",1);
+  fChain->SetBranchStatus("PDFWeights_Scale",1);  
+}
+
 void GetEffLumi::executeEvent(){
 
-  Event ev = GetEvent();
+  double MCweight = 1.;
+  if(!IsDATA) MCweight = gen_weight>0 ? 1. : -1. ;
 
-  FillHist("sumW", 0, ev.MCweight(), 1, 0., 1.);
+  FillHist("sumW", 0, MCweight, 1, 0., 1.);
   if(!IsDATA && PDFWeights_Scale->size()>0){
-    FillHist("sumW_Reweight", 0, ev.MCweight()*PDFWeights_Scale->at(0), 1, 0., 1.);
+    FillHist("sumW_Reweight", 0, MCweight*PDFWeights_Scale->at(0), 1, 0., 1.);
   }
 
 }


### PR DESCRIPTION
Faster GetEffLumi using SetBranchStatus function

I didn't compare the speed, but I think this way will be much faster than current version.
And with SetBranchStatus, I think we can make faster SkimTree. I will test it when server is free.

I tested it with 2016 DYJets sample, and it gave me same sumW with SampleCommonInfo.

