### PR TITLE
update skimming to use only one node. And faster skimming code

### DIFF
--- a/Analyzers/src/SkimTree_LRSMHighPt.C
+++ b/Analyzers/src/SkimTree_LRSMHighPt.C
@@ -48,6 +48,9 @@ void SkimTree_LRSMHighPt::initializeAnalyzer(){
     cout << "[SkimTree_LRSMHighPt::initializeAnalyzer]   " << triggers.at(i) << endl;
   }
 
+  fChain->SetBranchStatus("*",0);
+  fChain->SetBranchStatus("HLT_TriggerName",1);
+
 }
 
 void SkimTree_LRSMHighPt::executeEvent(){
@@ -56,6 +59,7 @@ void SkimTree_LRSMHighPt::executeEvent(){
   ev.SetTrigger(*HLT_TriggerName);
 
   if( ev.PassTrigger(triggers) ){
+    fChain->GetEntry(fChain->GetReadEntry(),true);
     newtree->Fill();
   }
 


### PR DESCRIPTION
1.  Faster skimming code using SetBranchStatus (Analyzers/src/SkimTree_LRSMHighPt.C)
- read full entries only for trigger passing events
- I expect small effect since there is still heavy writing. But anyway, it will faster than before.

2. Using only one node for skimming (python/SKFlat.py)
- due to slow IO of SNU servers... this way would provide more stable environment for other users. And total running time will be similar, I think.

3. adding for failure (python/SKFlat.py L335)
- I found that sometimes SKFlat.py cannot know its failure when there is no SF hist.
When we call Lepton SF function, it check histmap. And if SF hist doesn't exist, root script exit with EXIT_FAILURE code, but without any stderr. (only stdout saying there is no histogram)
So, we need to leave something at stderr when root script exit with non-zero exit code.
