### PR TITLE
Update/use vector reference

### DIFF
--- a/AnalyzerTools/include/MCCorrection.h
+++ b/AnalyzerTools/include/MCCorrection.h
@@ -43,27 +43,27 @@ public:
   double MuonID_SF(TString ID, double eta, double pt, int sys=0);
   double MuonISO_SF(TString ID, double eta, double pt, int sys=0);
   double MuonTrigger_Eff(TString ID, TString trig, int DataOrMC, double eta, double pt, int sys=0);
-  double MuonTrigger_SF(TString ID, TString trig, std::vector<Muon> muons, int sys=0);
-  double MuonTrigger_SF(TString ID, TString trig, std::vector<Muon *> muons, int sys=0);
+  double MuonTrigger_SF(TString ID, TString trig, const std::vector<Muon>& muons, int sys=0);
+  double MuonTrigger_SF(TString ID, TString trig, const std::vector<Muon *>& muons, int sys=0);
 
   std::map< TString, TH2F* > map_hist_Muon;
 
   double ElectronReco_SF(double sceta, double pt, int sys=0);
   double ElectronID_SF(TString ID, double sceta, double pt, int sys=0);
   double ElectronTrigger_Eff(TString ID, TString trig, int DataOrMC, double eta, double pt, int sys=0);
-  double ElectronTrigger_SF(TString ID, TString trig, std::vector<Electron> electrons, int sys=0);
-  double ElectronTrigger_SF(TString ID, TString trig, std::vector<Electron *> electrons, int sys=0);
+  double ElectronTrigger_SF(TString ID, TString trig, const std::vector<Electron>& electrons, int sys=0);
+  double ElectronTrigger_SF(TString ID, TString trig, const std::vector<Electron *>& electrons, int sys=0);
   std::map< TString, TH2F* > map_hist_Electron;
   std::map< TString, TGraphAsymmErrors* > map_graph_Electron;
 
   std::map< TString, TH2F* > map_hist_prefire;
-  double GetPrefireWeight(std::vector<Photon> photons, std::vector<Jet> jets, int sys);
+  double GetPrefireWeight(const std::vector<Photon>& photons, const std::vector<Jet>& jets, int sys);
 
   std::map< TString, TH1D* > map_hist_pileup;
   double GetPileUpWeightBySampleName(int N_pileup, int syst);
   double GetPileUpWeight(int N_pileup, int syst);
 
-  double GetTopPtReweight(std::vector<Gen> gens);
+  double GetTopPtReweight(const std::vector<Gen>& gens);
 
 };
 

--- a/AnalyzerTools/src/MCCorrection.C
+++ b/AnalyzerTools/src/MCCorrection.C
@@ -359,7 +359,7 @@ double MCCorrection::MuonTrigger_Eff(TString ID, TString trig, int DataOrMC, dou
 
 }
 
-double MCCorrection::MuonTrigger_SF(TString ID, TString trig, std::vector<Muon> muons, int sys){
+double MCCorrection::MuonTrigger_SF(TString ID, TString trig, const std::vector<Muon>& muons, int sys){
 
   if(ID=="Default") return 1.;
   if(trig=="Default") return 1.;
@@ -396,7 +396,7 @@ double MCCorrection::MuonTrigger_SF(TString ID, TString trig, std::vector<Muon> 
 
 }
 
-double MCCorrection::MuonTrigger_SF(TString ID, TString trig, std::vector<Muon *> muons, int sys){
+double MCCorrection::MuonTrigger_SF(TString ID, TString trig, const std::vector<Muon *>& muons, int sys){
 
   std::vector<Muon> muvec;
   for(unsigned int i=0; i<muons.size(); i++){
@@ -568,7 +568,7 @@ double MCCorrection::ElectronTrigger_Eff(TString ID, TString trig, int DataOrMC,
 
 }
 
-double MCCorrection::ElectronTrigger_SF(TString ID, TString trig, std::vector<Electron> electrons, int sys){
+double MCCorrection::ElectronTrigger_SF(TString ID, TString trig, const std::vector<Electron>& electrons, int sys){
 
   if(ID=="Default") return 1.;
   if(trig=="Default") return 1.;
@@ -605,7 +605,7 @@ double MCCorrection::ElectronTrigger_SF(TString ID, TString trig, std::vector<El
 
 }
 
-double MCCorrection::ElectronTrigger_SF(TString ID, TString trig, std::vector<Electron *> electrons, int sys){
+double MCCorrection::ElectronTrigger_SF(TString ID, TString trig, const std::vector<Electron *>& electrons, int sys){
 
   std::vector<Electron> muvec;
   for(unsigned int i=0; i<electrons.size(); i++){
@@ -617,7 +617,7 @@ double MCCorrection::ElectronTrigger_SF(TString ID, TString trig, std::vector<El
 
 }
 
-double MCCorrection::GetPrefireWeight(std::vector<Photon> photons, std::vector<Jet> jets, int sys){
+double MCCorrection::GetPrefireWeight(const std::vector<Photon>& photons, const std::vector<Jet>& jets, int sys){
 
   double photon_weight = 1.;
   double jet_weight = 1.;
@@ -719,7 +719,7 @@ double MCCorrection::GetPileUpWeight(int N_pileup, int syst){
 
 }
 
-double MCCorrection::GetTopPtReweight(std::vector<Gen> gens){
+double MCCorrection::GetTopPtReweight(const std::vector<Gen>& gens){
   //==== ref: https://twiki.cern.ch/twiki/bin/viewauth/CMS/TopPtReweighting2017
   //==== Only top quarks in SM ttbar events must be reweighted, 
   //==== not single tops or tops from BSM production mechanisms.
@@ -730,7 +730,7 @@ double MCCorrection::GetTopPtReweight(std::vector<Gen> gens){
   double toppt1=10000, toppt2=10000;
   bool found_top = false, found_atop = false;
 
-  for(vector<Gen>::iterator genit=gens.begin(); genit!=gens.end(); genit++){
+  for(vector<Gen>::const_iterator genit=gens.begin(); genit!=gens.end(); genit++){
     
     if(genit->Status() == 22){
       if(genit->PID() == 6){

--- a/Analyzers/include/AnalyzerCore.h
+++ b/Analyzers/include/AnalyzerCore.h
@@ -175,7 +175,8 @@ public:
   Electron ElectronUsePtCone(const Electron& electron);
   std::vector<Electron> ElectronApplyPtCut(const std::vector<Electron>& electrons, double ptcut);
   std::vector<Jet> JetsAwayFromFatJet(const std::vector<Jet>& jets, const std::vector<FatJet>& fatjets, double mindr=1.0);
-  std::vector<Jet> JetsVetoLeptonInside(const std::vector<Jet>& jets, const std::vector<Electron>& els, const std::vector<Muon>& mus);
+  std::vector<Jet> JetsVetoLeptonInside(const std::vector<Jet>& jets, const std::vector<Electron>& els, const std::vector<Muon>& mus, double dR=0.4);
+  std::vector<FatJet> FatJetsVetoLeptonInside(const std::vector<FatJet>& jets, const std::vector<Electron>& els, const std::vector<Muon>& mus, double dR=0.8);
   std::vector<Jet> JetsAwayFromPhoton(const std::vector<Jet>& jets, const std::vector<Photon>& photons, double mindr);
   Particle AddFatJetAndLepton(const FatJet& fatjet, const Lepton& lep);
 

--- a/Analyzers/include/AnalyzerCore.h
+++ b/Analyzers/include/AnalyzerCore.h
@@ -87,14 +87,14 @@ public:
   //==== Get AllObject in the begining, and apply cut
   //==================================================+
 
-  std::vector<Electron> SelectElectrons(std::vector<Electron>& electrons, TString id, double ptmin, double fetamax);
+  std::vector<Electron> SelectElectrons(const std::vector<Electron>& electrons, TString id, double ptmin, double fetamax);
 
   std::vector<Muon> UseTunePMuon(std::vector<Muon> muons);
-  std::vector<Muon> SelectMuons(std::vector<Muon>& muons, TString id, double ptmin, double fetamax);
+  std::vector<Muon> SelectMuons(const std::vector<Muon>& muons, TString id, double ptmin, double fetamax);
 
-  std::vector<Jet> SelectJets(std::vector<Jet>& jets, TString id, double ptmin, double fetamax);
+  std::vector<Jet> SelectJets(const std::vector<Jet>& jets, TString id, double ptmin, double fetamax);
 
-  std::vector<FatJet> SelectFatJets(std::vector<FatJet>& jets, TString id, double ptmin, double fetamax);
+  std::vector<FatJet> SelectFatJets(const std::vector<FatJet>& jets, TString id, double ptmin, double fetamax);
 
   //==================
   //==== Systematics

--- a/Analyzers/include/AnalyzerCore.h
+++ b/Analyzers/include/AnalyzerCore.h
@@ -87,14 +87,14 @@ public:
   //==== Get AllObject in the begining, and apply cut
   //==================================================+
 
-  std::vector<Electron> SelectElectrons(std::vector<Electron> electrons, TString id, double ptmin, double fetamax);
+  std::vector<Electron> SelectElectrons(std::vector<Electron>& electrons, TString id, double ptmin, double fetamax);
 
   std::vector<Muon> UseTunePMuon(std::vector<Muon> muons);
-  std::vector<Muon> SelectMuons(std::vector<Muon> muons, TString id, double ptmin, double fetamax);
+  std::vector<Muon> SelectMuons(std::vector<Muon>& muons, TString id, double ptmin, double fetamax);
 
-  std::vector<Jet> SelectJets(std::vector<Jet> jets, TString id, double ptmin, double fetamax);
+  std::vector<Jet> SelectJets(std::vector<Jet>& jets, TString id, double ptmin, double fetamax);
 
-  std::vector<FatJet> SelectFatJets(std::vector<FatJet> jets, TString id, double ptmin, double fetamax);
+  std::vector<FatJet> SelectFatJets(std::vector<FatJet>& jets, TString id, double ptmin, double fetamax);
 
   //==================
   //==== Systematics

--- a/Analyzers/include/AnalyzerCore.h
+++ b/Analyzers/include/AnalyzerCore.h
@@ -100,18 +100,18 @@ public:
   //==== Systematics
   //==================
 
-  std::vector<Electron> ScaleElectrons(std::vector<Electron> electrons, int sys);
-  std::vector<Electron> SmearElectrons(std::vector<Electron> electrons, int sys);
+  std::vector<Electron> ScaleElectrons(const std::vector<Electron>& electrons, int sys);
+  std::vector<Electron> SmearElectrons(const std::vector<Electron>& electrons, int sys);
 
-  std::vector<Muon> ScaleMuons(std::vector<Muon> muons, int sys);
+  std::vector<Muon> ScaleMuons(const std::vector<Muon>& muons, int sys);
 
-  std::vector<Jet> ScaleJets(std::vector<Jet> jets, int sys);
-  std::vector<Jet> SmearJets(std::vector<Jet> jets, int sys);
+  std::vector<Jet> ScaleJets(const std::vector<Jet>& jets, int sys);
+  std::vector<Jet> SmearJets(const std::vector<Jet>& jets, int sys);
 
-  std::vector<FatJet> ScaleFatJets(std::vector<FatJet> jets, int sys);
-  std::vector<FatJet> SmearFatJets(std::vector<FatJet> jets, int sys);
-  std::vector<FatJet> ScaleSDMassFatJets(std::vector<FatJet> jets, int sys);
-  std::vector<FatJet> SmearSDMassFatJets(std::vector<FatJet> jets, int sys);
+  std::vector<FatJet> ScaleFatJets(const std::vector<FatJet>& jets, int sys);
+  std::vector<FatJet> SmearFatJets(const std::vector<FatJet>& jets, int sys);
+  std::vector<FatJet> ScaleSDMassFatJets(const std::vector<FatJet>& jets, int sys);
+  std::vector<FatJet> SmearSDMassFatJets(const std::vector<FatJet>& jets, int sys);
 
   //====================
   //==== Event Filters

--- a/Analyzers/include/AnalyzerCore.h
+++ b/Analyzers/include/AnalyzerCore.h
@@ -71,8 +71,8 @@ public:
 
   //==== If TightIso is set, it calculate ptcone
   //==== If UseMini is true, Lepton::RelIso() returns MiniRelIso
-  std::vector<Lepton *> MakeLeptonPointerVector(std::vector<Muon>& muons, double TightIso=-999, bool UseMini=false);
-  std::vector<Lepton *> MakeLeptonPointerVector(std::vector<Electron>& electrons, double TightIso=-999, bool UseMini=false);
+  std::vector<Lepton *> MakeLeptonPointerVector(const std::vector<Muon>& muons, double TightIso=-999, bool UseMini=false);
+  std::vector<Lepton *> MakeLeptonPointerVector(const std::vector<Electron>& electrons, double TightIso=-999, bool UseMini=false);
 
   std::vector<Jet> GetAllJets();
   std::vector<Jet> GetJets(TString id, double ptmin, double fetamax);

--- a/Analyzers/include/AnalyzerCore.h
+++ b/Analyzers/include/AnalyzerCore.h
@@ -164,30 +164,30 @@ public:
   double MT2(TLorentzVector a, TLorentzVector b, Particle METv, double METgap);
   double projectedMET(TLorentzVector a, TLorentzVector b, Particle METv);
   bool HasFlag(TString flag);
-  std::vector<Muon> MuonWithoutGap(std::vector<Muon> muons);
-  std::vector<Muon> MuonPromptOnly(std::vector<Muon> muons, std::vector<Gen> gens);
-  std::vector<Muon> MuonUsePtCone(std::vector<Muon> muons);
-  Muon MuonUsePtCone(Muon muon);
-  Particle UpdateMET(Particle METv, std::vector<Muon> muons);
-  std::vector<Muon> MuonApplyPtCut(std::vector<Muon> muons, double ptcut);
-  std::vector<Electron> ElectronPromptOnly(std::vector<Electron> electrons, std::vector<Gen> gens);
-  std::vector<Electron> ElectronUsePtCone(std::vector<Electron> electrons);
-  Electron ElectronUsePtCone(Electron electron);
-  std::vector<Electron> ElectronApplyPtCut(std::vector<Electron> electrons, double ptcut);
-  std::vector<Jet> JetsAwayFromFatJet(std::vector<Jet> jets, std::vector<FatJet> fatjets, double mindr=1.0);
-  std::vector<Jet> JetsVetoLeptonInside(std::vector<Jet> jets, std::vector<Electron> els, std::vector<Muon> mus);
-  std::vector<Jet> JetsAwayFromPhoton(std::vector<Jet> jets, std::vector<Photon> photons, double mindr);
-  Particle AddFatJetAndLepton(FatJet fatjet, Lepton lep);
+  std::vector<Muon> MuonWithoutGap(const std::vector<Muon>& muons);
+  std::vector<Muon> MuonPromptOnly(const std::vector<Muon>& muons, const std::vector<Gen>& gens);
+  std::vector<Muon> MuonUsePtCone(const std::vector<Muon>& muons);
+  Muon MuonUsePtCone(const Muon& muon);
+  Particle UpdateMET(const Particle& METv, const std::vector<Muon>& muons);
+  std::vector<Muon> MuonApplyPtCut(const std::vector<Muon>& muons, double ptcut);
+  std::vector<Electron> ElectronPromptOnly(const std::vector<Electron>& electrons, const std::vector<Gen>& gens);
+  std::vector<Electron> ElectronUsePtCone(const std::vector<Electron>& electrons);
+  Electron ElectronUsePtCone(const Electron& electron);
+  std::vector<Electron> ElectronApplyPtCut(const std::vector<Electron>& electrons, double ptcut);
+  std::vector<Jet> JetsAwayFromFatJet(const std::vector<Jet>& jets, const std::vector<FatJet>& fatjets, double mindr=1.0);
+  std::vector<Jet> JetsVetoLeptonInside(const std::vector<Jet>& jets, const std::vector<Electron>& els, const std::vector<Muon>& mus);
+  std::vector<Jet> JetsAwayFromPhoton(const std::vector<Jet>& jets, const std::vector<Photon>& photons, double mindr);
+  Particle AddFatJetAndLepton(const FatJet& fatjet, const Lepton& lep);
 
   //==== GenMatching
 
-  void PrintGen(std::vector<Gen> gens);
-  Gen GetGenMatchedLepton(Lepton lep, std::vector<Gen> gens);
-  Gen GetGenMatchedPhoton(Lepton lep, std::vector<Gen> gens);
-  vector<int> TrackGenSelfHistory(Gen me, std::vector<Gen> gens);
-  bool IsFromHadron(Gen me, std::vector<Gen> gens);
-  int GetLeptonType(Lepton lep, std::vector<Gen> gens);
-  int GetGenPhotonType(Gen genph, std::vector<Gen> gens);
+  void PrintGen(const std::vector<Gen>& gens);
+  Gen GetGenMatchedLepton(const Lepton& lep, const std::vector<Gen>& gens);
+  Gen GetGenMatchedPhoton(const Lepton& lep, const std::vector<Gen>& gens);
+  vector<int> TrackGenSelfHistory(const Gen& me, const std::vector<Gen>& gens);
+  bool IsFromHadron(const Gen& me, const std::vector<Gen>& gens);
+  int GetLeptonType(const Lepton& lep, const std::vector<Gen>& gens);
+  int GetGenPhotonType(const Gen& genph, const std::vector<Gen>& gens);
   bool IsSignalPID(int pid);
 
   //==== Plotting

--- a/Analyzers/include/AnalyzerCore.h
+++ b/Analyzers/include/AnalyzerCore.h
@@ -89,7 +89,7 @@ public:
 
   std::vector<Electron> SelectElectrons(const std::vector<Electron>& electrons, TString id, double ptmin, double fetamax);
 
-  std::vector<Muon> UseTunePMuon(std::vector<Muon> muons);
+  std::vector<Muon> UseTunePMuon(const std::vector<Muon>& muons);
   std::vector<Muon> SelectMuons(const std::vector<Muon>& muons, TString id, double ptmin, double fetamax);
 
   std::vector<Jet> SelectJets(const std::vector<Jet>& jets, TString id, double ptmin, double fetamax);

--- a/Analyzers/src/AnalyzerCore.C
+++ b/Analyzers/src/AnalyzerCore.C
@@ -136,20 +136,19 @@ std::vector<Muon> AnalyzerCore::GetMuons(TString id, double ptmin, double fetama
   std::vector<Muon> muons = GetAllMuons();
   std::vector<Muon> out;
   for(unsigned int i=0; i<muons.size(); i++){
-    Muon this_muon=muons.at(i);
-    if(!( this_muon.Pt()>ptmin )){
-      //cout << "Fail Pt : pt = " << this_muon.Pt() << ", cut = " << ptmin << endl;
+    if(!( muons.at(i).Pt()>ptmin )){
+      //cout << "Fail Pt : pt = " << muons.at(i).Pt() << ", cut = " << ptmin << endl;
       continue;
     }
-    if(!( fabs(this_muon.Eta())<fetamax )){
-      //cout << "Fail Eta : eta = " << fabs(this_muon.Eta()) << ", cut = " << fetamax << endl;
+    if(!( fabs(muons.at(i).Eta())<fetamax )){
+      //cout << "Fail Eta : eta = " << fabs(muons.at(i).Eta()) << ", cut = " << fetamax << endl;
       continue;
     }
-    if(!( this_muon.PassID(id) )){
+    if(!( muons.at(i).PassID(id) )){
       //cout << "Fail ID" << endl;
       continue;
     }
-    out.push_back(this_muon);
+    out.push_back( muons.at(i) );
   }
   return out;
 
@@ -219,20 +218,19 @@ std::vector<Electron> AnalyzerCore::GetElectrons(TString id, double ptmin, doubl
   std::vector<Electron> electrons = GetAllElectrons();
   std::vector<Electron> out;
   for(unsigned int i=0; i<electrons.size(); i++){
-    Electron this_electron= electrons.at(i);
-    if(!( this_electron.Pt()>ptmin )){
-      //cout << "Fail Pt : pt = " << this_electron.Pt() << ", cut = " << ptmin << endl;
+    if(!( electrons.at(i).Pt()>ptmin )){
+      //cout << "Fail Pt : pt = " << electrons.at(i).Pt() << ", cut = " << ptmin << endl;
       continue;
     }
-    if(!( fabs(this_electron.scEta())<fetamax )){
-      //cout << "Fail Eta : eta = " << fabs(this_electron.scEta()) << ", cut = " << fetamax << endl;
+    if(!( fabs(electrons.at(i).scEta())<fetamax )){
+      //cout << "Fail Eta : eta = " << fabs(electrons.at(i).scEta()) << ", cut = " << fetamax << endl;
       continue;
     }
-    if(!( this_electron.PassID(id) )){
+    if(!( electrons.at(i).PassID(id) )){
       //cout << "Fail ID" << endl;
       continue;
     }
-    out.push_back(this_electron);
+    out.push_back( electrons.at(i) );
   }
   return out;
 
@@ -329,17 +327,16 @@ std::vector<Photon> AnalyzerCore::GetPhotons(TString id, double ptmin, double fe
   std::vector<Photon> photons = GetAllPhotons();
   std::vector<Photon> out;
   for(unsigned int i=0; i<photons.size(); i++){
-    Photon this_photon= photons.at(i);
-    if(!( this_photon.Pt()>ptmin )){
+    if(!( photons.at(i).Pt()>ptmin )){
       continue;
     }
-    if(!( fabs(this_photon.scEta())<fetamax )){
+    if(!( fabs(photons.at(i).scEta())<fetamax )){
       continue;
     }
-    if(!( this_photon.PassID(id) )){
+    if(!( photons.at(i).PassID(id) )){
       continue;
     }
-    out.push_back(this_photon);
+    out.push_back( photons.at(i) );
   }
   return out;
 }
@@ -396,20 +393,19 @@ std::vector<Jet> AnalyzerCore::GetJets(TString id, double ptmin, double fetamax)
   std::vector<Jet> jets = GetAllJets();
   std::vector<Jet> out;
   for(unsigned int i=0; i<jets.size(); i++){
-    Jet this_jet= jets.at(i);
-    if(!( this_jet.Pt()>ptmin )){
-      //cout << "Fail Pt : pt = " << this_jet.Pt() << ", cut = " << ptmin << endl;
+    if(!( jets.at(i).Pt()>ptmin )){
+      //cout << "Fail Pt : pt = " << jets.at(i).Pt() << ", cut = " << ptmin << endl;
       continue;
     }
-    if(!( fabs(this_jet.Eta())<fetamax )){
-      //cout << "Fail Eta : eta = " << fabs(this_jet.Eta()) << ", cut = " << fetamax << endl;
+    if(!( fabs(jets.at(i).Eta())<fetamax )){
+      //cout << "Fail Eta : eta = " << fabs(jets.at(i).Eta()) << ", cut = " << fetamax << endl;
       continue;
     }
-    if(!( this_jet.PassID(id) )){
+    if(!( jets.at(i).PassID(id) )){
       //cout << "Fail ID" << endl;
       continue;
     }
-    out.push_back(this_jet);
+    out.push_back( jets.at(i) );
   }
   return out;
 
@@ -465,20 +461,19 @@ std::vector<FatJet> AnalyzerCore::GetFatJets(TString id, double ptmin, double fe
   std::vector<FatJet> jets = GetAllFatJets();
   std::vector<FatJet> out;
   for(unsigned int i=0; i<jets.size(); i++){
-    FatJet this_jet= jets.at(i);
-    if(!( this_jet.Pt()>ptmin )){
-      //cout << "Fail Pt : pt = " << this_jet.Pt() << ", cut = " << ptmin << endl;
+    if(!( jets.at(i).Pt()>ptmin )){
+      //cout << "Fail Pt : pt = " << jets.at(i).Pt() << ", cut = " << ptmin << endl;
       continue;
     }
-    if(!( fabs(this_jet.Eta())<fetamax )){
-      //cout << "Fail Eta : eta = " << fabs(this_jet.Eta()) << ", cut = " << fetamax << endl;
+    if(!( fabs(jets.at(i).Eta())<fetamax )){
+      //cout << "Fail Eta : eta = " << fabs(jets.at(i).Eta()) << ", cut = " << fetamax << endl;
       continue;
     }
-    if(!( this_jet.PassID(id) )){
+    if(!( jets.at(i).PassID(id) )){
       //cout << "Fail ID" << endl;
       continue;
     }
-    out.push_back(this_jet);
+    out.push_back( jets.at(i) );
   }
   return out;
 

--- a/Analyzers/src/AnalyzerCore.C
+++ b/Analyzers/src/AnalyzerCore.C
@@ -236,7 +236,7 @@ std::vector<Electron> AnalyzerCore::GetElectrons(TString id, double ptmin, doubl
 
 }
 
-std::vector<Lepton *> AnalyzerCore::MakeLeptonPointerVector(std::vector<Muon>& muons, double TightIso, bool UseMini){
+std::vector<Lepton *> AnalyzerCore::MakeLeptonPointerVector(const std::vector<Muon>& muons, double TightIso, bool UseMini){
 
   std::vector<Lepton *> out;
   for(unsigned int i=0; i<muons.size(); i++){
@@ -258,7 +258,7 @@ std::vector<Lepton *> AnalyzerCore::MakeLeptonPointerVector(std::vector<Muon>& m
   return out;
 
 }
-std::vector<Lepton *> AnalyzerCore::MakeLeptonPointerVector(std::vector<Electron>& electrons, double TightIso, bool UseMini){
+std::vector<Lepton *> AnalyzerCore::MakeLeptonPointerVector(const std::vector<Electron>& electrons, double TightIso, bool UseMini){
 
   std::vector<Lepton *> out;
   for(unsigned int i=0; i<electrons.size(); i++){

--- a/Analyzers/src/AnalyzerCore.C
+++ b/Analyzers/src/AnalyzerCore.C
@@ -596,93 +596,89 @@ std::vector<Muon> AnalyzerCore::UseTunePMuon(std::vector<Muon> muons){
 
 }
 
-std::vector<Muon> AnalyzerCore::SelectMuons(std::vector<Muon> muons, TString id, double ptmin, double fetamax){
+std::vector<Muon> AnalyzerCore::SelectMuons(std::vector<Muon>& muons, TString id, double ptmin, double fetamax){
 
   std::vector<Muon> out;
   for(unsigned int i=0; i<muons.size(); i++){
-    Muon this_muon=muons.at(i);
-    if(!( this_muon.Pt()>ptmin )){
-      //cout << "Fail Pt : pt = " << this_muon.Pt() << ", cut = " << ptmin << endl;
+    if(!( muons.at(i).Pt()>ptmin )){
+      //cout << "Fail Pt : pt = " << muons.at(i).Pt() << ", cut = " << ptmin << endl;
       continue;
     }
-    if(!( fabs(this_muon.Eta())<fetamax )){
-      //cout << "Fail Eta : eta = " << fabs(this_muon.Eta()) << ", cut = " << fetamax << endl;
+    if(!( fabs(muons.at(i).Eta())<fetamax )){
+      //cout << "Fail Eta : eta = " << fabs(muons.at(i).Eta()) << ", cut = " << fetamax << endl;
       continue;
     }
-    if(!( this_muon.PassID(id) )){
+    if(!( muons.at(i).PassID(id) )){
       //cout << "Fail ID" << endl;
       continue;
     }
-    out.push_back(this_muon);
+    out.push_back( muons.at(i) );
   }
   return out;
 
 }
 
-std::vector<Electron> AnalyzerCore::SelectElectrons(std::vector<Electron> electrons, TString id, double ptmin, double fetamax){
+std::vector<Electron> AnalyzerCore::SelectElectrons(std::vector<Electron>& electrons, TString id, double ptmin, double fetamax){
 
   std::vector<Electron> out;
   for(unsigned int i=0; i<electrons.size(); i++){
-    Electron this_electron= electrons.at(i);
-    if(!( this_electron.Pt()>ptmin )){
-      //cout << "Fail Pt : pt = " << this_electron.Pt() << ", cut = " << ptmin << endl;
+    if(!( electrons.at(i).Pt()>ptmin )){
+      //cout << "Fail Pt : pt = " << electrons.at(i).Pt() << ", cut = " << ptmin << endl;
       continue;
     }
-    if(!( fabs(this_electron.scEta())<fetamax )){
-      //cout << "Fail Eta : eta = " << fabs(this_electron.scEta()) << ", cut = " << fetamax << endl;
+    if(!( fabs(electrons.at(i).scEta())<fetamax )){
+      //cout << "Fail Eta : eta = " << fabs(electrons.at(i).scEta()) << ", cut = " << fetamax << endl;
       continue;
     }
-    if(!( this_electron.PassID(id) )){
+    if(!( electrons.at(i).PassID(id) )){
       //cout << "Fail ID" << endl;
       continue;
     }
-    out.push_back(this_electron);
+    out.push_back(electrons.at(i));
   }
   return out;
 
 }
 
-std::vector<Jet> AnalyzerCore::SelectJets(std::vector<Jet> jets, TString id, double ptmin, double fetamax){
+std::vector<Jet> AnalyzerCore::SelectJets(std::vector<Jet>& jets, TString id, double ptmin, double fetamax){
 
   std::vector<Jet> out;
   for(unsigned int i=0; i<jets.size(); i++){
-    Jet this_jet= jets.at(i);
-    if(!( this_jet.Pt()>ptmin )){
-      //cout << "Fail Pt : pt = " << this_jet.Pt() << ", cut = " << ptmin << endl;
+    if(!( jets.at(i).Pt()>ptmin )){
+      //cout << "Fail Pt : pt = " << jets.at(i).Pt() << ", cut = " << ptmin << endl;
       continue;
     }
-    if(!( fabs(this_jet.Eta())<fetamax )){
-      //cout << "Fail Eta : eta = " << fabs(this_jet.Eta()) << ", cut = " << fetamax << endl;
+    if(!( fabs(jets.at(i).Eta())<fetamax )){
+      //cout << "Fail Eta : eta = " << fabs(jets.at(i).Eta()) << ", cut = " << fetamax << endl;
       continue;
     }
-    if(!( this_jet.PassID(id) )){
+    if(!( jets.at(i).PassID(id) )){
       //cout << "Fail ID" << endl;
       continue;
     }
-    out.push_back(this_jet);
+    out.push_back( jets.at(i) );
   }
   return out;
 
 }
 
-std::vector<FatJet> AnalyzerCore::SelectFatJets(std::vector<FatJet> jets, TString id, double ptmin, double fetamax){
+std::vector<FatJet> AnalyzerCore::SelectFatJets(std::vector<FatJet>& jets, TString id, double ptmin, double fetamax){
 
   std::vector<FatJet> out;
   for(unsigned int i=0; i<jets.size(); i++){
-    FatJet this_jet= jets.at(i);
-    if(!( this_jet.Pt()>ptmin )){
-      //cout << "Fail Pt : pt = " << this_jet.Pt() << ", cut = " << ptmin << endl;
+    if(!( jets.at(i).Pt()>ptmin )){
+      //cout << "Fail Pt : pt = " << jets.at(i).Pt() << ", cut = " << ptmin << endl;
       continue;
     }
-    if(!( fabs(this_jet.Eta())<fetamax )){
-      //cout << "Fail Eta : eta = " << fabs(this_jet.Eta()) << ", cut = " << fetamax << endl;
+    if(!( fabs(jets.at(i).Eta())<fetamax )){
+      //cout << "Fail Eta : eta = " << fabs(jets.at(i).Eta()) << ", cut = " << fetamax << endl;
       continue;
     }
-    if(!( this_jet.PassID(id) )){
+    if(!( jets.at(i).PassID(id) )){
       //cout << "Fail ID" << endl;
       continue;
     }
-    out.push_back(this_jet);
+    out.push_back( jets.at(i) );
   }
   return out;
 

--- a/Analyzers/src/AnalyzerCore.C
+++ b/Analyzers/src/AnalyzerCore.C
@@ -520,7 +520,7 @@ std::vector<Muon> AnalyzerCore::UseTunePMuon(const std::vector<Muon>& muons){
 
   std::vector<Muon> out;
   for(unsigned int i=0; i<muons.size(); i++){
-    //==== muons is a const vector. So in this function, we have to copy the elecements like below
+    //==== muons is a const vector. So in this function, we have to copy the elements like below
     Muon this_muon=muons.at(i);
 
     Particle this_tunep4 = this_muon.TuneP4();
@@ -680,10 +680,11 @@ std::vector<FatJet> AnalyzerCore::SelectFatJets(const std::vector<FatJet>& jets,
 
 }
 
-std::vector<Electron> AnalyzerCore::ScaleElectrons(std::vector<Electron> electrons, int sys){
+std::vector<Electron> AnalyzerCore::ScaleElectrons(const std::vector<Electron>& electrons, int sys){
 
   std::vector<Electron> out;
   for(unsigned int i=0; i<electrons.size(); i++){
+    //==== electrons is a const vector. So in this function, we have to copy the elements like below
     Electron this_electron = electrons.at(i);
 
     double this_sf = this_electron.EnShift(sys);
@@ -695,10 +696,11 @@ std::vector<Electron> AnalyzerCore::ScaleElectrons(std::vector<Electron> electro
   return out;
 
 }
-std::vector<Electron> AnalyzerCore::SmearElectrons(std::vector<Electron> electrons, int sys){
+std::vector<Electron> AnalyzerCore::SmearElectrons(const std::vector<Electron>& electrons, int sys){
 
   std::vector<Electron> out;
   for(unsigned int i=0; i<electrons.size(); i++){
+    //==== electrons is a const vector. So in this function, we have to copy the elements like below
     Electron this_electron = electrons.at(i);
 
     double this_sf = this_electron.ResShift(sys);
@@ -711,10 +713,11 @@ std::vector<Electron> AnalyzerCore::SmearElectrons(std::vector<Electron> electro
 
 }
 
-std::vector<Muon> AnalyzerCore::ScaleMuons(std::vector<Muon> muons, int sys){
+std::vector<Muon> AnalyzerCore::ScaleMuons(const std::vector<Muon>& muons, int sys){
 
   std::vector<Muon> out;
   for(unsigned int i=0; i<muons.size(); i++){
+    //==== muons is a const vector. So in this function, we have to copy the elements like below
     Muon this_muon = muons.at(i);
 
     //==== Even for TuneP muons, MomentumShift() are set correctly from AnalyzerCore::UseTunePMuon()
@@ -730,10 +733,11 @@ std::vector<Muon> AnalyzerCore::ScaleMuons(std::vector<Muon> muons, int sys){
 
 }
 
-std::vector<Jet> AnalyzerCore::ScaleJets(std::vector<Jet> jets, int sys){
+std::vector<Jet> AnalyzerCore::ScaleJets(const std::vector<Jet>& jets, int sys){
 
   std::vector<Jet> out;
   for(unsigned int i=0; i<jets.size(); i++){
+    //==== jets is a const vector. So in this function, we have to copy the elements like below
     Jet this_jet = jets.at(i);
 
     this_jet *= this_jet.EnShift(sys);
@@ -744,10 +748,11 @@ std::vector<Jet> AnalyzerCore::ScaleJets(std::vector<Jet> jets, int sys){
   return out;
 
 }
-std::vector<Jet> AnalyzerCore::SmearJets(std::vector<Jet> jets, int sys){
+std::vector<Jet> AnalyzerCore::SmearJets(const std::vector<Jet>& jets, int sys){
 
   std::vector<Jet> out;
   for(unsigned int i=0; i<jets.size(); i++){
+    //==== jets is a const vector. So in this function, we have to copy the elements like below
     Jet this_jet = jets.at(i);
 
     this_jet *= this_jet.ResShift(sys);
@@ -759,10 +764,11 @@ std::vector<Jet> AnalyzerCore::SmearJets(std::vector<Jet> jets, int sys){
 
 }
 
-std::vector<FatJet> AnalyzerCore::ScaleFatJets(std::vector<FatJet> jets, int sys){
+std::vector<FatJet> AnalyzerCore::ScaleFatJets(const std::vector<FatJet>& jets, int sys){
 
   std::vector<FatJet> out;
   for(unsigned int i=0; i<jets.size(); i++){
+    //==== jets is a const vector. So in this function, we have to copy the elements like below
     FatJet this_jet = jets.at(i);
 
     this_jet *= this_jet.EnShift(sys);
@@ -773,10 +779,11 @@ std::vector<FatJet> AnalyzerCore::ScaleFatJets(std::vector<FatJet> jets, int sys
   return out;
 
 }
-std::vector<FatJet> AnalyzerCore::SmearFatJets(std::vector<FatJet> jets, int sys){
+std::vector<FatJet> AnalyzerCore::SmearFatJets(const std::vector<FatJet>& jets, int sys){
 
   std::vector<FatJet> out;
   for(unsigned int i=0; i<jets.size(); i++){
+    //==== jets is a const vector. So in this function, we have to copy the elements like below
     FatJet this_jet = jets.at(i);
 
     this_jet *= this_jet.ResShift(sys);
@@ -788,10 +795,11 @@ std::vector<FatJet> AnalyzerCore::SmearFatJets(std::vector<FatJet> jets, int sys
 
 }
 //Fatjet SDMass systematics (https://twiki.cern.ch/twiki/bin/view/CMS/JetWtagging#2016%20scale%20factors%20and%20correctio)
-std::vector<FatJet> AnalyzerCore::ScaleSDMassFatJets(std::vector<FatJet> jets, int sys){
+std::vector<FatJet> AnalyzerCore::ScaleSDMassFatJets(const std::vector<FatJet>& jets, int sys){
   
   std::vector<FatJet> out;
   for(unsigned int i=0; i<jets.size(); i++){
+    //==== jets is a const vector. So in this function, we have to copy the elements like below
     FatJet this_jet = jets.at(i);
     double current_SDMass = this_jet.SDMass() * (1. + double(sys) * 0.0094 );
     this_jet.SetSDMass( current_SDMass );
@@ -802,10 +810,11 @@ std::vector<FatJet> AnalyzerCore::ScaleSDMassFatJets(std::vector<FatJet> jets, i
   return out;
   
 }
-std::vector<FatJet> AnalyzerCore::SmearSDMassFatJets(std::vector<FatJet> jets, int sys){
+std::vector<FatJet> AnalyzerCore::SmearSDMassFatJets(const std::vector<FatJet>& jets, int sys){
 
   std::vector<FatJet> out;
   for(unsigned int i=0; i<jets.size(); i++){
+    //==== jets is a const vector. So in this function, we have to copy the elements like below
     FatJet this_jet = jets.at(i);
     double current_SDMass = this_jet.SDMass() * (1. + double(sys) * 0.20 );
     this_jet.SetSDMass( current_SDMass );

--- a/Analyzers/src/AnalyzerCore.C
+++ b/Analyzers/src/AnalyzerCore.C
@@ -591,7 +591,7 @@ std::vector<Muon> AnalyzerCore::UseTunePMuon(std::vector<Muon> muons){
 
 }
 
-std::vector<Muon> AnalyzerCore::SelectMuons(std::vector<Muon>& muons, TString id, double ptmin, double fetamax){
+std::vector<Muon> AnalyzerCore::SelectMuons(const std::vector<Muon>& muons, TString id, double ptmin, double fetamax){
 
   std::vector<Muon> out;
   for(unsigned int i=0; i<muons.size(); i++){
@@ -613,7 +613,7 @@ std::vector<Muon> AnalyzerCore::SelectMuons(std::vector<Muon>& muons, TString id
 
 }
 
-std::vector<Electron> AnalyzerCore::SelectElectrons(std::vector<Electron>& electrons, TString id, double ptmin, double fetamax){
+std::vector<Electron> AnalyzerCore::SelectElectrons(const std::vector<Electron>& electrons, TString id, double ptmin, double fetamax){
 
   std::vector<Electron> out;
   for(unsigned int i=0; i<electrons.size(); i++){
@@ -635,7 +635,7 @@ std::vector<Electron> AnalyzerCore::SelectElectrons(std::vector<Electron>& elect
 
 }
 
-std::vector<Jet> AnalyzerCore::SelectJets(std::vector<Jet>& jets, TString id, double ptmin, double fetamax){
+std::vector<Jet> AnalyzerCore::SelectJets(const std::vector<Jet>& jets, TString id, double ptmin, double fetamax){
 
   std::vector<Jet> out;
   for(unsigned int i=0; i<jets.size(); i++){
@@ -657,7 +657,7 @@ std::vector<Jet> AnalyzerCore::SelectJets(std::vector<Jet>& jets, TString id, do
 
 }
 
-std::vector<FatJet> AnalyzerCore::SelectFatJets(std::vector<FatJet>& jets, TString id, double ptmin, double fetamax){
+std::vector<FatJet> AnalyzerCore::SelectFatJets(const std::vector<FatJet>& jets, TString id, double ptmin, double fetamax){
 
   std::vector<FatJet> out;
   for(unsigned int i=0; i<jets.size(); i++){

--- a/Analyzers/src/AnalyzerCore.C
+++ b/Analyzers/src/AnalyzerCore.C
@@ -516,10 +516,11 @@ std::vector<Gen> AnalyzerCore::GetGens(){
 
 }
 
-std::vector<Muon> AnalyzerCore::UseTunePMuon(std::vector<Muon> muons){
+std::vector<Muon> AnalyzerCore::UseTunePMuon(const std::vector<Muon>& muons){
 
   std::vector<Muon> out;
   for(unsigned int i=0; i<muons.size(); i++){
+    //==== muons is a const vector. So in this function, we have to copy the elecements like below
     Muon this_muon=muons.at(i);
 
     Particle this_tunep4 = this_muon.TuneP4();

--- a/Analyzers/src/AnalyzerCore.C
+++ b/Analyzers/src/AnalyzerCore.C
@@ -1245,7 +1245,7 @@ std::vector<Jet> AnalyzerCore::JetsAwayFromFatJet(const std::vector<Jet>& jets, 
 
 }
 
-std::vector<Jet> AnalyzerCore::JetsVetoLeptonInside(const std::vector<Jet>& jets, const std::vector<Electron>& els, const std::vector<Muon>& mus){
+std::vector<Jet> AnalyzerCore::JetsVetoLeptonInside(const std::vector<Jet>& jets, const std::vector<Electron>& els, const std::vector<Muon>& mus, double dR){
 
   std::vector<Jet> out;
   for(unsigned int i=0; i<jets.size(); i++){
@@ -1253,7 +1253,7 @@ std::vector<Jet> AnalyzerCore::JetsVetoLeptonInside(const std::vector<Jet>& jets
     bool HasLeptonInside = false;
 
     for(unsigned int j=0; j<els.size(); j++){
-      if( jets.at(i).DeltaR( els.at(j) ) < 0.4 ){
+      if( jets.at(i).DeltaR( els.at(j) ) < dR ){
         HasLeptonInside = true;
         break;
       }
@@ -1261,7 +1261,7 @@ std::vector<Jet> AnalyzerCore::JetsVetoLeptonInside(const std::vector<Jet>& jets
     if(HasLeptonInside) continue;
 
     for(unsigned int j=0; j<mus.size(); j++){
-      if( jets.at(i).DeltaR( mus.at(j) ) < 0.4 ){
+      if( jets.at(i).DeltaR( mus.at(j) ) < dR ){
         HasLeptonInside = true;
         break;
       }
@@ -1272,6 +1272,39 @@ std::vector<Jet> AnalyzerCore::JetsVetoLeptonInside(const std::vector<Jet>& jets
     out.push_back( jets.at(i) );
 
   }
+  return out;
+
+}
+
+std::vector<FatJet> AnalyzerCore::FatJetsVetoLeptonInside(const std::vector<FatJet>& jets, const std::vector<Electron>& els, const std::vector<Muon>& mus, double dR){
+
+  std::vector<FatJet> out;
+  for(unsigned int i=0; i<jets.size(); i++){
+    FatJet this_jet = jets.at(i);
+
+    bool HasLeptonInside = false;
+
+    for(unsigned int j=0; j<els.size(); j++){
+      if( this_jet.DeltaR( els.at(j) ) < dR ){
+        HasLeptonInside = true;
+        break;
+      }
+    }
+    if(HasLeptonInside) continue;
+
+    for(unsigned int j=0; j<mus.size(); j++){
+      if( this_jet.DeltaR( mus.at(j) ) < dR ){
+        HasLeptonInside = true;
+        break;
+      }
+    }
+    if(HasLeptonInside) continue;
+
+    //==== if all fine,
+    out.push_back( this_jet );
+
+  }
+
   return out;
 
 }

--- a/Analyzers/src/AnalyzerCore.C
+++ b/Analyzers/src/AnalyzerCore.C
@@ -1082,22 +1082,21 @@ bool AnalyzerCore::HasFlag(TString flag){
 
 }
 
-std::vector<Muon> AnalyzerCore::MuonWithoutGap(std::vector<Muon> muons){
+std::vector<Muon> AnalyzerCore::MuonWithoutGap(const std::vector<Muon>& muons){
 
   std::vector<Muon> out;
   for(unsigned int i=0; i<muons.size(); i++){
-    Muon this_muon = muons.at(i);
-    double this_eta = fabs( this_muon.Eta() );
+    double this_eta = fabs( muons.at(i).Eta() );
     if( 1.444 <= this_eta && this_eta < 1.566 ) continue;
 
-    out.push_back(this_muon);
+    out.push_back( muons.at(i) );
   }
 
   return out;
 
 }
 
-std::vector<Muon> AnalyzerCore::MuonPromptOnly(std::vector<Muon> muons, std::vector<Gen> gens){
+std::vector<Muon> AnalyzerCore::MuonPromptOnly(const std::vector<Muon>& muons, const std::vector<Gen>& gens){
 
   if(IsDATA) return muons;
 
@@ -1112,27 +1111,31 @@ std::vector<Muon> AnalyzerCore::MuonPromptOnly(std::vector<Muon> muons, std::vec
 
 }
 
-std::vector<Muon> AnalyzerCore::MuonUsePtCone(std::vector<Muon> muons){
+std::vector<Muon> AnalyzerCore::MuonUsePtCone(const std::vector<Muon>& muons){
 
   std::vector<Muon> out;
 
   for(unsigned int i=0; i<muons.size(); i++){
-    muons.at(i).SetPtEtaPhiM( muons.at(i).PtCone(), muons.at(i).Eta(), muons.at(i).Phi(), muons.at(i).M() );
-    out.push_back( muons.at(i) );
+    //==== muons is a const vector. So in this function, we have to copy the elements like below
+    Muon this_muon = muons.at(i);
+    this_muon.SetPtEtaPhiM( muons.at(i).PtCone(), muons.at(i).Eta(), muons.at(i).Phi(), muons.at(i).M() );
+    out.push_back( this_muon );
   }
 
   return out;
 
 }
 
-Muon AnalyzerCore::MuonUsePtCone(Muon muon){
+Muon AnalyzerCore::MuonUsePtCone(const Muon& muon){
 
-  muon.SetPtEtaPhiM( muon.PtCone(), muon.Eta(), muon.Phi(), muon.M() );
-  return muon;
+  //==== muon is a const object. So in this function, we have to copy the object like below
+  Muon this_muon = muon;
+  this_muon.SetPtEtaPhiM( muon.PtCone(), muon.Eta(), muon.Phi(), muon.M() );
+  return this_muon;
 
 }
 
-Particle AnalyzerCore::UpdateMET(Particle METv, std::vector<Muon> muons){
+Particle AnalyzerCore::UpdateMET(const Particle& METv, const std::vector<Muon>& muons){
 
   float met_x = METv.Px();
   float met_y = METv.Py();
@@ -1157,7 +1160,7 @@ Particle AnalyzerCore::UpdateMET(Particle METv, std::vector<Muon> muons){
 
 }
 
-std::vector<Muon> AnalyzerCore::MuonApplyPtCut(std::vector<Muon> muons, double ptcut){
+std::vector<Muon> AnalyzerCore::MuonApplyPtCut(const std::vector<Muon>& muons, double ptcut){
 
   std::vector<Muon> out;
 
@@ -1170,7 +1173,7 @@ std::vector<Muon> AnalyzerCore::MuonApplyPtCut(std::vector<Muon> muons, double p
 
 }
 
-std::vector<Electron> AnalyzerCore::ElectronPromptOnly(std::vector<Electron> electrons, std::vector<Gen> gens){
+std::vector<Electron> AnalyzerCore::ElectronPromptOnly(const std::vector<Electron>& electrons, const std::vector<Gen>& gens){
 
   if(IsDATA) return electrons;
 
@@ -1185,27 +1188,31 @@ std::vector<Electron> AnalyzerCore::ElectronPromptOnly(std::vector<Electron> ele
 
 }
 
-std::vector<Electron> AnalyzerCore::ElectronUsePtCone(std::vector<Electron> electrons){
+std::vector<Electron> AnalyzerCore::ElectronUsePtCone(const std::vector<Electron>& electrons){
 
   std::vector<Electron> out;
 
   for(unsigned int i=0; i<electrons.size(); i++){
-    electrons.at(i).SetPtEtaPhiM( electrons.at(i).PtCone(), electrons.at(i).Eta(), electrons.at(i).Phi(), electrons.at(i).M() );
-    out.push_back( electrons.at(i) );
+    //==== electrons is a const vector. So in this function, we have to copy the elements like below
+    Electron this_electron = electrons.at(i);
+    this_electron.SetPtEtaPhiM( electrons.at(i).PtCone(), electrons.at(i).Eta(), electrons.at(i).Phi(), electrons.at(i).M() );
+    out.push_back( this_electron );
   }
 
   return out;
 
 }
 
-Electron AnalyzerCore::ElectronUsePtCone(Electron electron){
+Electron AnalyzerCore::ElectronUsePtCone(const Electron& electron){
 
-  electron.SetPtEtaPhiM( electron.PtCone(), electron.Eta(), electron.Phi(), electron.M() );
-  return electron;
+  //==== electron is a const object. So in this function, we have to copy the object like below
+  Electron this_electron = electron;
+  this_electron.SetPtEtaPhiM( electron.PtCone(), electron.Eta(), electron.Phi(), electron.M() );
+  return this_electron;
 
 }
 
-std::vector<Electron> AnalyzerCore::ElectronApplyPtCut(std::vector<Electron> electrons, double ptcut){
+std::vector<Electron> AnalyzerCore::ElectronApplyPtCut(const std::vector<Electron>& electrons, double ptcut){
 
   std::vector<Electron> out;
 
@@ -1218,7 +1225,7 @@ std::vector<Electron> AnalyzerCore::ElectronApplyPtCut(std::vector<Electron> ele
 
 }
 
-std::vector<Jet> AnalyzerCore::JetsAwayFromFatJet(std::vector<Jet> jets, std::vector<FatJet> fatjets, double mindr){
+std::vector<Jet> AnalyzerCore::JetsAwayFromFatJet(const std::vector<Jet>& jets, const std::vector<FatJet>& fatjets, double mindr){
 
   std::vector<Jet> out;
   for(unsigned int i=0; i<jets.size(); i++){
@@ -1238,16 +1245,15 @@ std::vector<Jet> AnalyzerCore::JetsAwayFromFatJet(std::vector<Jet> jets, std::ve
 
 }
 
-std::vector<Jet> AnalyzerCore::JetsVetoLeptonInside(std::vector<Jet> jets, std::vector<Electron> els, std::vector<Muon> mus){
+std::vector<Jet> AnalyzerCore::JetsVetoLeptonInside(const std::vector<Jet>& jets, const std::vector<Electron>& els, const std::vector<Muon>& mus){
 
   std::vector<Jet> out;
   for(unsigned int i=0; i<jets.size(); i++){
-    Jet this_jet = jets.at(i);
 
     bool HasLeptonInside = false;
 
     for(unsigned int j=0; j<els.size(); j++){
-      if( this_jet.DeltaR( els.at(j) ) < 0.4 ){
+      if( jets.at(i).DeltaR( els.at(j) ) < 0.4 ){
         HasLeptonInside = true;
         break;
       }
@@ -1255,7 +1261,7 @@ std::vector<Jet> AnalyzerCore::JetsVetoLeptonInside(std::vector<Jet> jets, std::
     if(HasLeptonInside) continue;
 
     for(unsigned int j=0; j<mus.size(); j++){
-      if( this_jet.DeltaR( mus.at(j) ) < 0.4 ){
+      if( jets.at(i).DeltaR( mus.at(j) ) < 0.4 ){
         HasLeptonInside = true;
         break;
       }
@@ -1263,14 +1269,14 @@ std::vector<Jet> AnalyzerCore::JetsVetoLeptonInside(std::vector<Jet> jets, std::
     if(HasLeptonInside) continue;
 
     //==== if all fine,
-    out.push_back( this_jet );
+    out.push_back( jets.at(i) );
 
   }
   return out;
 
 }
 
-std::vector<Jet> AnalyzerCore::JetsAwayFromPhoton(std::vector<Jet> jets, std::vector<Photon> photons, double mindr){
+std::vector<Jet> AnalyzerCore::JetsAwayFromPhoton(const std::vector<Jet>& jets, const std::vector<Photon>& photons, double mindr){
   
   std::vector<Jet> out;
   for(unsigned int i=0; i<jets.size(); i++){
@@ -1291,7 +1297,7 @@ std::vector<Jet> AnalyzerCore::JetsAwayFromPhoton(std::vector<Jet> jets, std::ve
 }
 
 
-Particle AnalyzerCore::AddFatJetAndLepton(FatJet fatjet, Lepton lep){
+Particle AnalyzerCore::AddFatJetAndLepton(const FatJet& fatjet, const Lepton& lep){
 
   if(fatjet.DeltaR( lep )<0.8){
     return fatjet;
@@ -1305,7 +1311,7 @@ Particle AnalyzerCore::AddFatJetAndLepton(FatJet fatjet, Lepton lep){
 //=========================================================
 //==== Gen Matching Tools
 
-void AnalyzerCore::PrintGen(std::vector<Gen> gens){
+void AnalyzerCore::PrintGen(const std::vector<Gen>& gens){
 
   cout << "===========================================================" << endl;
   cout << "RunNumber:EventNumber = " << run << ":" << event << endl;
@@ -1319,7 +1325,7 @@ void AnalyzerCore::PrintGen(std::vector<Gen> gens){
 
 }
 
-Gen AnalyzerCore::GetGenMatchedLepton(Lepton lep, std::vector<Gen> gens){
+Gen AnalyzerCore::GetGenMatchedLepton(const Lepton& lep, const std::vector<Gen>& gens){
 
   //==== find status 1 lepton
 
@@ -1355,7 +1361,7 @@ Gen AnalyzerCore::GetGenMatchedLepton(Lepton lep, std::vector<Gen> gens){
 
 }
 
-Gen AnalyzerCore::GetGenMatchedPhoton(Lepton lep, std::vector<Gen> gens){
+Gen AnalyzerCore::GetGenMatchedPhoton(const Lepton& lep, const std::vector<Gen>& gens){
 
   double min_dR = 0.2;
   Gen gen_closest;
@@ -1390,7 +1396,7 @@ Gen AnalyzerCore::GetGenMatchedPhoton(Lepton lep, std::vector<Gen> gens){
 
 }
 
-vector<int> AnalyzerCore::TrackGenSelfHistory(Gen me, std::vector<Gen> gens){
+vector<int> AnalyzerCore::TrackGenSelfHistory(const Gen& me, const std::vector<Gen>& gens){
 
   int myindex = me.Index();
 
@@ -1419,7 +1425,7 @@ vector<int> AnalyzerCore::TrackGenSelfHistory(Gen me, std::vector<Gen> gens){
 
 }
 
-bool AnalyzerCore::IsFromHadron(Gen me, std::vector<Gen> gens){
+bool AnalyzerCore::IsFromHadron(const Gen& me, const std::vector<Gen>& gens){
 
   bool out = false;
 
@@ -1482,7 +1488,7 @@ bool AnalyzerCore::IsFromHadron(Gen me, std::vector<Gen> gens){
 
 }
 
-int AnalyzerCore::GetLeptonType(Lepton lep, std::vector<Gen> gens){
+int AnalyzerCore::GetLeptonType(const Lepton& lep, const std::vector<Gen>& gens){
 
   //==== [Type]
   //====  1 : EWPrompt
@@ -1701,7 +1707,7 @@ int AnalyzerCore::GetLeptonType(Lepton lep, std::vector<Gen> gens){
 
 }
 
-int AnalyzerCore::GetGenPhotonType(Gen genph, std::vector<Gen> gens){
+int AnalyzerCore::GetGenPhotonType(const Gen& genph, const std::vector<Gen>& gens){
 
   //==== [Type]
   //====  0 : Invalid input or Error or HardScatter is input when hardscatter is not final state

--- a/DataFormats/include/Electron.h
+++ b/DataFormats/include/Electron.h
@@ -44,7 +44,7 @@ public:
   enum EtaRegion{
     IB, OB, GAP, EC
   };
-  inline EtaRegion etaRegion(){
+  inline EtaRegion etaRegion() const {
     double sceta = fabs(scEta());
     if( sceta < 0.8 ) return IB;
     else if( sceta < 1.444 ) return OB;
@@ -104,21 +104,21 @@ public:
   inline bool passMVAID_iso_WP90() const {return PassSelector(POG_MVA_ISO_WP90); }
   inline bool passHEEPID() const {return PassSelector(POG_HEEP); }
 
-  bool Pass_SUSYMVAWP(TString wp);
-  bool Pass_SUSYTight();
-  bool Pass_SUSYLoose();
+  bool Pass_SUSYMVAWP(TString wp) const;
+  bool Pass_SUSYTight() const;
+  bool Pass_SUSYLoose() const;
 
   void SetRelPFIso_Rho(double r);
   double EA();
 
   //==== ID
-  bool PassID(TString ID);
-  bool Pass_TESTID();
+  bool PassID(TString ID) const;
+  bool Pass_TESTID() const;
 
-  bool Pass_CutBasedLooseNoIso();
-  bool Pass_CutBasedVetoNoIso();
-  bool Pass_CutBasedLoose();
-  bool Pass_CutBasedVeto();
+  bool Pass_CutBasedLooseNoIso() const;
+  bool Pass_CutBasedVetoNoIso() const;
+  bool Pass_CutBasedLoose() const;
+  bool Pass_CutBasedVeto() const;
   void SetRho(double r);
   inline double Rho() const { return j_Rho; }
 

--- a/DataFormats/include/FatJet.h
+++ b/DataFormats/include/FatJet.h
@@ -36,7 +36,7 @@ public:
   inline bool Pass_tightJetID() const { return j_tightJetID; }
   inline bool Pass_tightLepVetoJetID() const { return j_tightLepVetoJetID; }
 
-  bool PassID(TString ID);
+  bool PassID(TString ID) const;
 
   enum Tagger{
     CSVv2,

--- a/DataFormats/include/FatJet.h
+++ b/DataFormats/include/FatJet.h
@@ -15,8 +15,8 @@ public:
   void SetEnergyFractions(double cH, double nH, double nEM, double cEM, double muE);
   void SetMultiplicities(double cM, double nM);
   void SetLSF(double lsf, int lsf_PID);
-  double LSF();
-  double LSF_PID();
+  double LSF() const;
+  double LSF_PID() const;
 
   void SetEnShift(double en_up, double en_down);
   double EnShift(int s){

--- a/DataFormats/include/Jet.h
+++ b/DataFormats/include/Jet.h
@@ -36,7 +36,7 @@ public:
   inline bool Pass_tightJetID() const { return j_tightJetID; }
   inline bool Pass_tightLepVetoJetID() const { return j_tightLepVetoJetID; }
 
-  bool PassID(TString ID);
+  bool PassID(TString ID) const;
 
   enum Tagger{
     CSVv2,

--- a/DataFormats/include/Muon.h
+++ b/DataFormats/include/Muon.h
@@ -94,11 +94,10 @@ public:
   inline double TunePPtError() const {return j_TunePPtError;}
 
   //==== ID
-  bool PassID(TString ID);
-  bool Pass_POGTight();
-  bool Pass_POGTightWithTightIso();
-  bool Pass_POGHighPtWithLooseTrkIso();
-  bool Pass_TESTID();
+  bool PassID(TString ID) const;
+  bool Pass_POGTightWithTightIso() const;
+  bool Pass_POGHighPtWithLooseTrkIso() const;
+  bool Pass_TESTID() const;
 
 private:
 

--- a/DataFormats/src/Electron.C
+++ b/DataFormats/src/Electron.C
@@ -119,7 +119,7 @@ double Electron::EA(){
 
 }
 
-bool Electron::PassID(TString ID){
+bool Electron::PassID(TString ID) const{
 
   //==== XXX veto Gap Always
   if(etaRegion()==GAP) return false;
@@ -146,7 +146,7 @@ bool Electron::PassID(TString ID){
   return false;
 }
 
-bool Electron::Pass_SUSYMVAWP(TString wp){
+bool Electron::Pass_SUSYMVAWP(TString wp) const{
 
   double sceta = fabs(scEta());
 
@@ -174,7 +174,7 @@ bool Electron::Pass_SUSYMVAWP(TString wp){
 
 }
 
-bool Electron::Pass_SUSYTight(){
+bool Electron::Pass_SUSYTight() const{
   if(! Pass_SUSYMVAWP("Tight") ) return false;
   if(! (MiniRelIso()<0.1) ) return false;	
   if(! (fabs(dXY())<0.05 && fabs(dZ())<0.1 && fabs(IP3D()/IP3Derr())<8.) ) return false;
@@ -184,7 +184,7 @@ bool Electron::Pass_SUSYTight(){
   return true;
 }
 
-bool Electron::Pass_SUSYLoose(){
+bool Electron::Pass_SUSYLoose() const{
   if(! Pass_SUSYMVAWP("Loose") ) return false;
   if(! (MiniRelIso()<0.4) ) return false;
   if(! (fabs(dXY())<0.05 && fabs(dZ())<0.1 && fabs(IP3D()/IP3Derr())<8.) ) return false;
@@ -196,13 +196,13 @@ bool Electron::Pass_SUSYLoose(){
 
 //==== TEST ID
 
-bool Electron::Pass_TESTID(){
+bool Electron::Pass_TESTID() const{
   return true;
 }
 
 
 
-bool Electron::Pass_CutBasedLooseNoIso(){
+bool Electron::Pass_CutBasedLooseNoIso() const{
 
   if( fabs(scEta()) <= 1.479 ){
 
@@ -233,7 +233,7 @@ bool Electron::Pass_CutBasedLooseNoIso(){
 
 }
 
-bool Electron::Pass_CutBasedVetoNoIso(){
+bool Electron::Pass_CutBasedVetoNoIso() const{
   
   if( fabs(scEta()) <= 1.479 ){
     
@@ -264,7 +264,7 @@ bool Electron::Pass_CutBasedVetoNoIso(){
 
 }
 
-bool Electron::Pass_CutBasedLoose(){
+bool Electron::Pass_CutBasedLoose() const{
 
   if( fabs(scEta()) <= 1.479 ){
 
@@ -297,7 +297,7 @@ bool Electron::Pass_CutBasedLoose(){
 
 }
 
-bool Electron::Pass_CutBasedVeto(){
+bool Electron::Pass_CutBasedVeto() const{
 
   if( fabs(scEta()) <= 1.479 ){
 

--- a/DataFormats/src/FatJet.C
+++ b/DataFormats/src/FatJet.C
@@ -105,7 +105,7 @@ void FatJet::SetTightLepVetoJetID(double b){
   j_tightLepVetoJetID = b;
 }
 
-bool FatJet::PassID(TString ID){
+bool FatJet::PassID(TString ID) const {
 
   if(ID=="tight") return Pass_tightJetID();
   if(ID=="tightLepVeto") return Pass_tightLepVetoJetID();

--- a/DataFormats/src/FatJet.C
+++ b/DataFormats/src/FatJet.C
@@ -81,10 +81,10 @@ void FatJet::SetLSF(double lsf, int lsf_PID){
   j_lsf = lsf;
   j_lsf_pid = lsf_PID;
 }
-double FatJet::LSF(){
+double FatJet::LSF() const{
   return j_lsf;
 }
-double FatJet::LSF_PID(){
+double FatJet::LSF_PID() const{
   return j_lsf_pid;
 }
 

--- a/DataFormats/src/Jet.C
+++ b/DataFormats/src/Jet.C
@@ -91,7 +91,7 @@ void Jet::SetTightLepVetoJetID(double b){
   j_tightLepVetoJetID = b;
 }
 
-bool Jet::PassID(TString ID){
+bool Jet::PassID(TString ID) const {
 
   if(ID=="tight") return Pass_tightJetID();
   if(ID=="tightLepVeto") return Pass_tightLepVetoJetID();

--- a/DataFormats/src/Muon.C
+++ b/DataFormats/src/Muon.C
@@ -86,7 +86,7 @@ void Muon::SetTuneP4(double pt, double pt_err, double eta, double phi, double q)
   j_TunePPtError = pt_err;
 }
 
-bool Muon::PassID(TString ID){
+bool Muon::PassID(TString ID) const {
   //==== POG
   if(ID=="POGTight") return isPOGTight();
   if(ID=="POGHighPt") return isPOGHighPt();
@@ -103,12 +103,12 @@ bool Muon::PassID(TString ID){
   return false;
 
 }
-bool Muon::Pass_POGTightWithTightIso(){
+bool Muon::Pass_POGTightWithTightIso() const {
   if(!( isPOGTight() )) return false;
   if(!( RelIso()<0.15 ))  return false;
   return true;
 }
-bool Muon::Pass_POGHighPtWithLooseTrkIso(){
+bool Muon::Pass_POGHighPtWithLooseTrkIso() const {
   if(!( isPOGHighPt() )) return false;
   if(!( TrkIso()/TuneP4().Pt()<0.1 )) return false;
   return true;
@@ -116,6 +116,6 @@ bool Muon::Pass_POGHighPtWithLooseTrkIso(){
 
 //==== TEST ID
 
-bool Muon::Pass_TESTID(){
+bool Muon::Pass_TESTID() const {
   return true;
 }


### PR DESCRIPTION
This is to make the functions safer, and a very tiny, small, almost negligible improvement of memory usage and timings..

If we replace "vector<T>" to "const vector<T>& " in the arguments of functions, we don't copy the vector, and also will not modify the input vector.

To do this, we also have to modify member functions of the objects (i.e., Muon,Electron, Jet, and FatJet) to const functions.

Some of the DataFormats files are modified, and you might have some conflicts.
And if you've added customized ID functions (e.g., Jet::Pass_HNID()),
you now also have to modify it to const functions.
 