### PR TITLE
Add TrackerLayers to Muon class; Add IsGsfCtfScPixChargeConsistent to Electron class;

### DIFF
--- a/Analyzers/src/AnalyzerCore.C
+++ b/Analyzers/src/AnalyzerCore.C
@@ -113,6 +113,7 @@ std::vector<Muon> AnalyzerCore::GetAllMuons(){
     mu.SetisPOGHighPt(muon_ishighpt->at(i));
     mu.SetChi2(muon_normchi->at(i));
     mu.SetIso(muon_PfChargedHadronIsoR04->at(i),muon_PfNeutralHadronIsoR04->at(i),muon_PfGammaIsoR04->at(i),muon_PFSumPUIsoR04->at(i),muon_trkiso->at(i));
+    mu.SetTrackerLayers(muon_trackerLayers->at(i));
 
     //==== Should be set after Eta is set
     mu.SetMiniIso(
@@ -179,6 +180,7 @@ std::vector<Electron> AnalyzerCore::GetAllElectrons(){
     el.SetPassConversionVeto(electron_passConversionVeto->at(i));
     el.SetNMissingHits(electron_mHits->at(i));
     el.SetRho(Rho);
+    el.SetIsGsfCtfScPixChargeConsistent(electron_isGsfCtfScPixChargeConsistent->at(i));
 
     el.SetCutBasedIDVariables(
       electron_Full5x5_SigmaIEtaIEta->at(i),

--- a/DataFormats/include/Electron.h
+++ b/DataFormats/include/Electron.h
@@ -122,6 +122,9 @@ public:
   void SetRho(double r);
   inline double Rho() const { return j_Rho; }
 
+  void SetIsGsfCtfScPixChargeConsistent(bool b);
+  inline bool IsGsfCtfScPixChargeConsistent() const { return j_isGsfCtfScPixChargeConsistent; }
+    
 private:
 
   double j_En_up;
@@ -138,6 +141,7 @@ private:
   double j_RelPFIso_Rho;
 
   double j_Rho;
+  int j_isGsfCtfScPixChargeConsistent;
 
   ClassDef(Electron,1)
 

--- a/DataFormats/include/Muon.h
+++ b/DataFormats/include/Muon.h
@@ -98,6 +98,9 @@ public:
   bool Pass_POGTightWithTightIso() const;
   bool Pass_POGHighPtWithLooseTrkIso() const;
   bool Pass_TESTID() const;
+  
+  void SetTrackerLayers(int n);
+  inline int TrackerLayers() const { return j_trackerLayers; }
 
 private:
 
@@ -108,6 +111,7 @@ private:
   double j_MiniAODPt, j_MiniAODTunePPt, j_MomentumScaleUp, j_MomentumScaleDown;
   Particle j_TuneP4;
   double j_TunePPtError;
+  int j_trackerLayers;
 
   ClassDef(Muon,1);
 };

--- a/DataFormats/src/Electron.C
+++ b/DataFormats/src/Electron.C
@@ -29,6 +29,7 @@ Electron::Electron(){
   j_dr03HcalDepth1TowerSumEt = -999.;
   j_IDBit = 0;
   j_Rho = -999.;
+  j_isGsfCtfScPixChargeConsistent = false;
   this->SetLeptonFlavour(ELECTRON);
 }
 
@@ -332,4 +333,8 @@ bool Electron::Pass_CutBasedVeto() const{
 
 void Electron::SetRho(double r){
   j_Rho = r;
+}
+
+void Electron::SetIsGsfCtfScPixChargeConsistent(bool b){
+  j_isGsfCtfScPixChargeConsistent = b;
 }

--- a/DataFormats/src/Muon.C
+++ b/DataFormats/src/Muon.C
@@ -14,6 +14,7 @@ Muon::Muon() : Lepton() {
   j_MomentumScaleUp = -999.;
   j_MomentumScaleDown = -999.;
   j_TunePPtError = -999.;
+  j_trackerLayers = 0;
 }
 
 Muon::~Muon(){
@@ -118,4 +119,8 @@ bool Muon::Pass_POGHighPtWithLooseTrkIso() const {
 
 bool Muon::Pass_TESTID() const {
   return true;
+}
+
+void Muon::SetTrackerLayers(int n){
+  j_trackerLayers = n;
 }


### PR DESCRIPTION
- for RoccoR v3
Muon::TrackerLayers() 
Muon::SetTrackerLayers(int n)

- for SMP analysis. I used long name in order to follow the convention. 
Electron::IsGsfCtfScPixChargeConsistent(); 
Electron::SetIsGsfCtfScPixChargeConsistent(bool b);

Tested with modified ExampleRun
