### PR TITLE
:(

### DIFF
--- a/DataFormats/include/Electron.h
+++ b/DataFormats/include/Electron.h
@@ -47,7 +47,7 @@ public:
   inline EtaRegion etaRegion() const {
     double sceta = fabs(scEta());
     if( sceta < 0.8 ) return IB;
-    else if( sceta < 1.4442 ) return OB;
+    else if( sceta < 1.444 ) return OB;
     else if( sceta < 1.566 ) return GAP;
     else return EC;
   }


### PR DESCRIPTION
Arg... EGamma TnP tool use 1.444. So if we have sceta=1.44403 electron, it will use gap values but most likely they are not reliable.

Let's use 1.444..