### PR TITLE
Update AnalyzerCore for TH3; TH1 SetDirectory(0) for speed

### DIFF
--- a/Analyzers/include/AnalyzerCore.h
+++ b/Analyzers/include/AnalyzerCore.h
@@ -4,6 +4,7 @@
 #include "TLorentzVector.h"
 #include "TString.h"
 #include "TMath.h"
+#include "TH3.h"
 #include <sstream>      
 
 #include "SKFlatNtuple.h"
@@ -199,9 +200,11 @@ public:
 
   std::map< TString, TH1D* > maphist_TH1D;
   std::map< TString, TH2D* > maphist_TH2D;
+  std::map< TString, TH3D* > maphist_TH3D;
 
   TH1D* GetHist1D(TString histname);
   TH2D* GetHist2D(TString histname);
+  TH3D* GetHist3D(TString histname);
 
   void FillHist(TString histname, double value, double weight, int n_bin, double x_min, double x_max);
   void FillHist(TString histname, double value, double weight, int n_bin, double *xbins);
@@ -215,6 +218,18 @@ public:
                 double weight,
                 int n_binx, double *xbins,
                 int n_biny, double *ybins);
+  void FillHist(TString histname,
+		double value_x, double value_y, double value_z,
+		double weight,
+		int n_binx, double x_min, double x_max,
+		int n_biny, double y_min, double y_max,
+		int n_binz, double z_min, double z_max);
+  void FillHist(TString histname,
+		double value_x, double value_y, double value_z,
+		double weight,
+		int n_binx, double *xbins,
+		int n_biny, double *ybins,
+		int n_binz, double *zbins);
 
   //==== JSFillHist : 1D
   std::map< TString, std::map<TString, TH1D*> > JSmaphist_TH1D;

--- a/Analyzers/src/AnalyzerCore.C
+++ b/Analyzers/src/AnalyzerCore.C
@@ -26,6 +26,11 @@ AnalyzerCore::~AnalyzerCore(){
   }
   maphist_TH2D.clear();
 
+  for(std::map< TString, TH3D* >::iterator mapit = maphist_TH3D.begin(); mapit!=maphist_TH3D.end(); mapit++){
+    delete mapit->second;
+  }
+  maphist_TH3D.clear();
+  
   //=== delete btag map
   for(std::map<TString,BTagSFUtil*>::iterator it = MapBTagSF.begin(); it!= MapBTagSF.end(); it++){
     delete it->second;
@@ -1875,11 +1880,23 @@ TH2D* AnalyzerCore::GetHist2D(TString histname){
 
 }
 
+TH3D* AnalyzerCore::GetHist3D(TString histname){
+  
+  TH3D *h = NULL;
+  std::map<TString, TH3D*>::iterator mapit = maphist_TH3D.find(histname);
+  if(mapit != maphist_TH3D.end()) return mapit->second;
+  
+  return h;
+  
+}
+
+
 void AnalyzerCore::FillHist(TString histname, double value, double weight, int n_bin, double x_min, double x_max){
 
   TH1D *this_hist = GetHist1D(histname);
   if( !this_hist ){
     this_hist = new TH1D(histname, "", n_bin, x_min, x_max);
+    this_hist->SetDirectory(NULL);
     maphist_TH1D[histname] = this_hist;
   }
 
@@ -1892,6 +1909,7 @@ void AnalyzerCore::FillHist(TString histname, double value, double weight, int n
   TH1D *this_hist = GetHist1D(histname);
   if( !this_hist ){
     this_hist = new TH1D(histname, "", n_bin, xbins);
+    this_hist->SetDirectory(NULL);
     maphist_TH1D[histname] = this_hist;
   }
 
@@ -1908,6 +1926,7 @@ void AnalyzerCore::FillHist(TString histname,
   TH2D *this_hist = GetHist2D(histname);
   if( !this_hist ){
     this_hist = new TH2D(histname, "", n_binx, x_min, x_max, n_biny, y_min, y_max);
+    this_hist->SetDirectory(NULL);
     maphist_TH2D[histname] = this_hist;
   }
 
@@ -1924,11 +1943,48 @@ void AnalyzerCore::FillHist(TString histname,
   TH2D *this_hist = GetHist2D(histname);
   if( !this_hist ){
     this_hist = new TH2D(histname, "", n_binx, xbins, n_biny, ybins);
+    this_hist->SetDirectory(NULL);
     maphist_TH2D[histname] = this_hist;
   }
 
   this_hist->Fill(value_x, value_y, weight);
 
+}
+
+void AnalyzerCore::FillHist(TString histname,
+			    double value_x, double value_y, double value_z,
+			    double weight,
+			    int n_binx, double x_min, double x_max,
+			    int n_biny, double y_min, double y_max,
+			    int n_binz, double z_min, double z_max){
+  
+  TH3D *this_hist = GetHist3D(histname);
+  if( !this_hist ){
+    this_hist = new TH3D(histname, "", n_binx, x_min, x_max, n_biny, y_min, y_max, n_binz, z_min, z_max);
+    this_hist->SetDirectory(NULL);
+    maphist_TH3D[histname] = this_hist;
+  }
+  
+  this_hist->Fill(value_x, value_y, value_z, weight);
+  
+}
+
+void AnalyzerCore::FillHist(TString histname,
+			    double value_x, double value_y, double value_z,
+			    double weight,
+			    int n_binx, double *xbins,
+			    int n_biny, double *ybins,
+			    int n_binz, double *zbins){
+  
+  TH3D *this_hist = GetHist3D(histname);
+  if( !this_hist ){
+    this_hist = new TH3D(histname, "", n_binx, xbins, n_biny, ybins, n_binz, zbins);
+    this_hist->SetDirectory(NULL);
+    maphist_TH3D[histname] = this_hist;
+  }
+  
+  this_hist->Fill(value_x, value_y, value_z, weight);
+  
 }
 
 TH1D* AnalyzerCore::JSGetHist1D(TString suffix, TString histname){
@@ -2037,6 +2093,18 @@ void AnalyzerCore::WriteHist(){
     outfile->cd();
   }
   for(std::map< TString, TH2D* >::iterator mapit = maphist_TH2D.begin(); mapit!=maphist_TH2D.end(); mapit++){
+    TString this_fullname=mapit->second->GetName();
+    TString this_name=this_fullname(this_fullname.Last('/')+1,this_fullname.Length());
+    TString this_suffix=this_fullname(0,this_fullname.Last('/'));
+    TDirectory *dir = outfile->GetDirectory(this_suffix);
+    if(!dir){
+      outfile->mkdir(this_suffix);
+    }
+    outfile->cd(this_suffix);
+    mapit->second->Write(this_name);
+    outfile->cd();
+  }
+  for(std::map< TString, TH3D* >::iterator mapit = maphist_TH3D.begin(); mapit!=maphist_TH3D.end(); mapit++){
     TString this_fullname=mapit->second->GetName();
     TString this_name=this_fullname(this_fullname.Last('/')+1,this_fullname.Length());
     TString this_suffix=this_fullname(0,this_fullname.Last('/'));


### PR DESCRIPTION
1. Update AnalyzerCore for TH3

1. TH1 SetDirectory(0) for speed
  -- I think there is some issue TDirectory when there are too many object. Destructor of an object is very slow (10000obj /10min) when there are more than O(100000) objects in same TDirectory (probably due to L3 cache missing).
  -- We register all of the TH in the c++ map, and delete them at the end. So, we can simply SetDirectory(NULL) to solve the problem. This results in very fast deleting (~sec).