### PR TITLE
GEScaleSyst: verbose was not initilized.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ KNU :  ~/scartch/
 ```
 #### When first time gie clone, use the option "--recursive" to initiate the submodules
 git clone --recursive git@github.com:CMSSNU/SKFlatAnalyzer.git
+cd SKFlatAnalyzer
 #### add your remote repo
 git remote add <nickname> git@github.com:<gitaccount>/SKFlatAnalyzer.git
 git checkout <your working branch>
 
 #### First time setup script
 source bin/FirstTimeSetup.sh 
+source setup.sh
 
 #### You have to edit user info
 #### First, copy the temply using the command below


### PR DESCRIPTION
This is an updated in the submodule GEScaleSyst.

https://github.com/jedori0228/GEScaleSyst/commit/06dbb793af0d6f3850fd9ee10ae4793227dfa5b0

In external/GEScaleSyst/, `int verbose` was not initialized.

I found when I'm unlucky, it is set to `1` and printing all the logs.

This is now fixed by initializing in the constructor.