### PR TITLE
add rootmap; add --memory argument in SKFlat.py; check AnalyzerCore::…

### DIFF
--- a/AnalyzerTools/makefile
+++ b/AnalyzerTools/makefile
@@ -3,6 +3,7 @@ OBJDIR = obj
 DEPDIR = $(OBJDIR)/dep
 SRCDIR = src
 INCDIR = include
+ADDITIONAL_ROOTMAPLIBRARY= -rml libDataFormats.so -rml libHist.so
 
 include $(SKFlat_WD)/makefile.common
 

--- a/Analyzers/makefile
+++ b/Analyzers/makefile
@@ -3,6 +3,7 @@ OBJDIR = obj
 DEPDIR = $(OBJDIR)/dep
 SRCDIR = src
 INCDIR = include
+ADDITIONAL_ROOTMAPLIBRARY = -rml libAnalyzerTools.so -rml libGEScaleSyst.so -rml libDataFormats.so -rml libTree.so
 
 include $(SKFlat_WD)/makefile.common
 

--- a/Analyzers/src/AnalyzerCore.C
+++ b/Analyzers/src/AnalyzerCore.C
@@ -2,6 +2,7 @@
 
 AnalyzerCore::AnalyzerCore(){
 
+  outfile = NULL;
   mcCorr = new MCCorrection();
   puppiCorr = new PuppiSoftdropMassCorr();
   fakeEst = new FakeBackgroundEstimator();
@@ -33,7 +34,8 @@ AnalyzerCore::~AnalyzerCore(){
   
   //==== output rootfile
 
-  outfile->Close();
+  if(outfile) outfile->Close();
+  delete outfile;
 
   //==== Tools
 

--- a/DataFormats/makefile
+++ b/DataFormats/makefile
@@ -3,5 +3,6 @@ OBJDIR = obj
 DEPDIR = $(OBJDIR)/dep
 SRCDIR = src
 INCDIR = include
+ADDITIONAL_ROOTMAPLIBRARY= -rml libPhysics.so
 
 include $(SKFlat_WD)/makefile.common

--- a/makefile
+++ b/makefile
@@ -3,18 +3,22 @@ all: DataFormats AnalyzerTools GEScaleSyst Analyzers Archive
 DataFormats::
 	(cd DataFormats; make)
 	(mvexist.sh DataFormats/src/DataFormats_Dict_rdict.pcm lib/)
+	(mvexist.sh DataFormats/libDataFormats.rootmap lib/)
 
 AnalyzerTools::
 	(cd AnalyzerTools; make)
 	(mvexist.sh AnalyzerTools/src/AnalyzerTools_Dict_rdict.pcm lib/)
+	(mvexist.sh AnalyzerTools/libAnalyzerTools.rootmap lib/)
 
 GEScaleSyst::
 	(cd external/GEScaleSyst; make)
 	(mvexist.sh external/GEScaleSyst/GEScaleSyst_Dict_rdict.pcm lib/)
+	(mvexist.sh external/GEScaleSyst/libGEScaleSyst.rootmap lib/)
 
 Analyzers::
 	(cd Analyzers; make)
 	(mvexist.sh Analyzers/src/Analyzers_Dict_rdict.pcm lib/)
+	(mvexist.sh Analyzers/libAnalyzers.rootmap lib/)
 
 Archive::
 	(tar -zcf lib/DataFormats.tar.gz DataFormats)

--- a/makefile.common
+++ b/makefile.common
@@ -41,7 +41,7 @@ OLIST = $(patsubst %.C,%.o,$(notdir $(CPPLIST)))
 # Rule to create the dictionary
 $(DICTFILE): $(HLIST) $(DICTLDEF)
 	@echo "Generating dictionary $@"
-	@$(shell root-config --exec-prefix)/bin/rootcint -f $(DICTFILE) $(INCLUDES) $^
+	@$(shell root-config --exec-prefix)/bin/rootcint -f $(DICTFILE) -rmf lib$(LIBRARY).rootmap -rml lib$(LIBRARY).so $(ADDITIONAL_ROOTMAPLIBRARY) $(INCLUDES) $^
 
 # Rule to comile the dictionary
 $(DICTOBJ): $(DICTFILE)

--- a/python/SKFlat.py
+++ b/python/SKFlat.py
@@ -26,6 +26,7 @@ parser.add_argument('--FastSim', action='store_true')
 parser.add_argument('--userflags', dest='Userflags', default="")
 parser.add_argument('--nmax', dest='NMax', default=0, type=int)
 parser.add_argument('--reduction', dest='Reduction', default=1, type=float)
+parser.add_argument('--memory', dest='Memory', default=0, type=float)
 parser.add_argument('--batchname',dest='BatchName', default="")
 args = parser.parse_args()
 
@@ -401,6 +402,9 @@ queue {0}
       concurrency_limits=''
       if args.NMax:
         concurrency_limits='concurrency_limits = n'+str(args.NMax)+'.'+os.getenv("USER")
+      request_memory=''
+      if args.Memory:
+        request_memory='request_memory = '+str(args.Memory)
       print>>submit_command,'''executable = {1}.sh
 universe   = vanilla
 arguments  = $(Process)
@@ -412,8 +416,9 @@ output = job_$(Process).log
 error = job_$(Process).err
 transfer_output_remaps = "hists.root = output/hists_$(Process).root"
 {2}
+{3}
 queue {0}
-'''.format(str(NJobs), commandsfilename,concurrency_limits)
+'''.format(str(NJobs), commandsfilename,concurrency_limits,request_memory)
       submit_command.close()
 
   CheckTotalNFile=0
@@ -437,14 +442,7 @@ queue {0}
       os.system('mkdir -p '+thisjob_dir)
       runCfileFullPath = thisjob_dir+'run.C'
 
-    IncludeLine  = 'R__LOAD_LIBRARY(libPhysics.so)\n'
-    IncludeLine += 'R__LOAD_LIBRARY(libTree.so)\n'
-    IncludeLine += 'R__LOAD_LIBRARY(libHist.so)\n'
-    IncludeLine += 'R__LOAD_LIBRARY({0}libDataFormats.so)\n'.format(libdir)
-    IncludeLine += 'R__LOAD_LIBRARY({0}libAnalyzerTools.so)\n'.format(libdir)
-    IncludeLine += 'R__LOAD_LIBRARY({0}libGEScaleSyst.so)\n'.format(libdir)
-    IncludeLine += 'R__LOAD_LIBRARY({0}libAnalyzers.so)\n'.format(libdir)
-    IncludeLine += 'R__LOAD_LIBRARY(/cvmfs/cms.cern.ch/slc7_amd64_gcc700/external/lhapdf/6.2.1-gnimlf3/lib/libLHAPDF.so)\n'
+    IncludeLine = 'R__LOAD_LIBRARY(/cvmfs/cms.cern.ch/slc7_amd64_gcc700/external/lhapdf/6.2.1-gnimlf3/lib/libLHAPDF.so)\n'
 
     out = open(runCfileFullPath, 'w')
     print>>out,'''{3}

--- a/python/SKFlat.py
+++ b/python/SKFlat.py
@@ -337,6 +337,9 @@ eval `scramv1 runtime -sh`
 cd -
 source /cvmfs/cms.cern.ch/$SCRAM_ARCH/cms/$cmsswrel/external/$SCRAM_ARCH/bin/thisroot.sh
 
+### modifying LD_LIBRARY_PATH to use libraries in base_rundir
+export LD_LIBRARY_PATH=$(echo $LD_LIBRARY_PATH|sed 's@'$SKFlat_WD'/lib@{0}/lib@')
+
 while [ "$SumNoAuth" -ne 0 ]; do
 
   if [ "$Trial" -gt 9999 ]; then
@@ -361,7 +364,7 @@ while [ "$SumNoAuth" -ne 0 ]; do
 done
 
 cat err.log >&2
-'''.format(SKFlatV, base_rundir, SCRAM_ARCH, cmsswrel)
+'''.format(MasterJobDir, base_rundir, SCRAM_ARCH, cmsswrel)
     run_commands.close()
 
     submit_command = open(base_rundir+'/submit.jds','w')


### PR DESCRIPTION
…outfile before Close();

There are 3 updates
1. Add rootmap files for automatic library loading (`makefile`s, `SKFlat.py`)
    * Define needed libraries for custom classes in rootmap files
    * Now, we don't need to road library explicitly. It will be automatic.
    * Removing some lines for library loading in `SKFlat.py` 
    * Check it in root prompt without loading any library
```
[hsseo@tamsa2 ]$ root -l -b
root [0] ExampleRun m
[TDirectoryHelper::GetTempDirectory()] histDir name = MCCorrection0
[TDirectoryHelper::GetTempDirectory()] histDir name = PuppiSoftdropMassCorr0
[TDirectoryHelper::GetTempDirectory()] histDir name = FakeBackgroundEstimator0
[TDirectoryHelper::GetTempDirectory()] histDir name = CFBackgroundEstimator0
(ExampleRun &) @0x7fdb9aa98000
root [1] .q
```

1. Add `--memory` argument in SKFlat.py
    * If memory usage exceed 4G, the job will be held in tamsa.
    * Use this argument to request more memory

1. Check `AnalyzerCore::outfile` before `TFile::Close()`
    * It will make an error if `outfile` is never opened.

