### PR TITLE
Update/hee pv7.0 2018 prompt

### DIFF
--- a/AnalyzerTools/src/MCCorrection.C
+++ b/AnalyzerTools/src/MCCorrection.C
@@ -526,10 +526,11 @@ double MCCorrection::ElectronID_SF(TString ID, double sceta, double pt, int sys)
       this_SF_err = sqrt(this_SF_staterr*this_SF_staterr+this_SF_systerr*this_SF_systerr);
     }
     else if(DataYear==2018){
-      //==== TODO not yet supported
-      //==== copying 2017
-      this_SF         = (IsBarrel ? 0.967 : 0.973);
-      this_SF_staterr = (IsBarrel ? 0.001 : 0.002);
+
+      //==== https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammaRunIIRecommendations#HEEPv7_0_2018Prompt
+
+      this_SF         = (IsBarrel ? 0.969 : 0.984);
+      this_SF_staterr = (IsBarrel ? 0.000 : 0.001);
 
       if(IsBarrel) this_SF_systerr = (pt<90. ? 0.01 : min(1.+(pt-90.)*0.0022,3.)*0.01) * this_SF;
       else         this_SF_systerr = (pt<90. ? 0.02 : min(1.+(pt-90.)*0.0143,5.)*0.01) * this_SF;

--- a/DataFormats/include/Electron.h
+++ b/DataFormats/include/Electron.h
@@ -117,6 +117,7 @@ public:
   inline bool passMVAID_iso_WP80() const {return PassSelector(POG_MVA_ISO_WP80); }
   inline bool passMVAID_iso_WP90() const {return PassSelector(POG_MVA_ISO_WP90); }
   inline bool passHEEPID() const {return PassSelector(POG_HEEP); }
+  bool passHEEP2018Prompt() const;
 
   bool Pass_SUSYMVAWP(TString wp) const;
   bool Pass_SUSYTight() const;

--- a/DataFormats/src/Electron.C
+++ b/DataFormats/src/Electron.C
@@ -153,6 +153,7 @@ bool Electron::PassID(TString ID) const{
   if(ID=="passMediumID") return passMediumID();
   if(ID=="passTightID") return passTightID();
   if(ID=="passHEEPID") return passHEEPID();
+  if(ID=="passHEEPID2018Prompt") return passHEEP2018Prompt();
   if(ID=="passMVAID_noIso_WP80") return passMVAID_noIso_WP80();
   if(ID=="passMVAID_noIso_WP90") return passMVAID_noIso_WP90();
   if(ID=="passMVAID_iso_WP80") return passMVAID_iso_WP80();

--- a/DataFormats/src/Electron.C
+++ b/DataFormats/src/Electron.C
@@ -169,6 +169,35 @@ bool Electron::PassID(TString ID) const{
   return false;
 }
 
+bool Electron::passHEEP2018Prompt() const {
+
+  //==== If not endcap, use original function
+  if( fabs(scEta()) < 1.566 ) return passHEEPID();
+
+  //==== https://github.com/CMSSNU/SKFlatMaker/blob/Run2Legacy_v4/SKFlatMaker/python/SKFlatMaker_cfi.py#L37-L50
+  int HEEPcutbit = IDCutBit().at(11);
+
+  //==== https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Applying_Individual_Cuts_of_a_Se
+  //==== We will modify H/E (bit nr=6) and EM+Had_depth1 (bit nr=8) isolation cut for EndCap for 2018
+  //==== Decimal without H/E and EM+Had_depth1 = (4096-1) - (1<<6) - (1<<8) = 3775
+  if(! ( (HEEPcutbit&3775)==3775 ) ) return false;
+
+  //==== new cutd : https://indico.cern.ch/event/831669/contributions/3485543/attachments/1871797/3084930/ApprovalSlides_EE_v3.pdf, page 9
+
+  //==== new H/E cut
+//double cutValue_HoverE =                                      5 / scE() + 0.05; // original cut
+  double cutValue_HoverE = ( -0.4 + 0.4 * fabs(scEta()) ) * Rho() / scE() + 0.05;
+  if(! (HoverE()<cutValue_HoverE) ) return false;
+
+  //==== new EM+Had_depth1 cut
+//double cutValue_emhaddep1 = UncorrPt() > 50. ? 2.5 + 0.03 * (UncorrPt()-50.) +                        0.28 * Rho() : 2.5 +                        0.28 * Rho(); // original cut
+  double cutValue_emhaddep1 = UncorrPt() > 50. ? 2.5 + 0.03 * (UncorrPt()-50.) + (0.15 + 0.07*fabs(scEta())) * Rho() : 2.5 + (0.15 + 0.07*fabs(scEta())) * Rho();
+  if(! ( dr03EcalRecHitSumEt() + dr03HcalDepth1TowerSumEt() < cutValue_emhaddep1 ) ) return false;
+
+  return true;
+
+}
+
 bool Electron::Pass_SUSYMVAWP(TString wp) const{
 
   double sceta = fabs(scEta());
@@ -199,7 +228,7 @@ bool Electron::Pass_SUSYMVAWP(TString wp) const{
 
 bool Electron::Pass_SUSYTight() const{
   if(! Pass_SUSYMVAWP("Tight") ) return false;
-  if(! (MiniRelIso()<0.1) ) return false;	
+  if(! (MiniRelIso()<0.1) ) return false;
   if(! (fabs(dXY())<0.05 && fabs(dZ())<0.1 && fabs(IP3D()/IP3Derr())<8.) ) return false;
   if(! PassConversionVeto() ) return false;
   if(! (NMissingHits()==0) ) return false;


### PR DESCRIPTION
HEEP ID for 2018 endcap electron (EE) has been updated : https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammaRunIIRecommendations#HEEPv7_0_2018Prompt

We have to modify two cuts; 1) H/E 2) EM+Had_depth1 isolation

Out of the 12 cut variables of HEEP ID, we "H/E" has bit number "6" and "EM+Had_depth1 isolation" has bit number 8 : https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Applying_Individual_Cuts_of_a_Se

If an electron pass original HEEP ID, the ID cut bit is 2^12-1 = 4095.
If we remove above two cuts, the ID cut bit is (4095) - (2^6) - (2^8) = 3775.

So, the new ID will be requiring below three cuts :
- ( (ID cut bit) & 3775 ) = 3775
- New H/E cut
- New EM+Had_depth1 isolation cut

This is implemented as Electron::passHEEP2018Prompt() function. Objects under DataFormats do not know about the DataYear of input samples, so you have to write this in your Analyzer code to use correct ID.

Also, 2018 HEEP ID SF has been updated; only SF nominal values (+ stat error) are updated, and systematics remains same.