### PR TITLE
replace JSFillHist to FillHist

### DIFF
--- a/Analyzers/src/AnalyzerCore.C
+++ b/Analyzers/src/AnalyzerCore.C
@@ -2080,26 +2080,26 @@ void AnalyzerCore::FillLeptonPlots(std::vector<Lepton *> leps, TString this_regi
 
     Lepton *lep = leps[i];
 
-    JSFillHist(this_region, "Lepton_"+this_itoa+"_Pt_"+this_region, lep->Pt(), weight, 1000, 0., 1000.);
-    JSFillHist(this_region, "Lepton_"+this_itoa+"_Eta_"+this_region, lep->Eta(), weight, 60, -3., 3.);
-    JSFillHist(this_region, "Lepton_"+this_itoa+"_RelIso_"+this_region, lep->RelIso(), weight, 100, 0., 1.);
-    JSFillHist(this_region, "Lepton_"+this_itoa+"_MiniRelIso_"+this_region, lep->MiniRelIso(), weight, 100, 0., 1.);
+    FillHist(this_region+"/Lepton_"+this_itoa+"_Pt_"+this_region, lep->Pt(), weight, 1000, 0., 1000.);
+    FillHist(this_region+"/Lepton_"+this_itoa+"_Eta_"+this_region, lep->Eta(), weight, 60, -3., 3.);
+    FillHist(this_region+"/Lepton_"+this_itoa+"_RelIso_"+this_region, lep->RelIso(), weight, 100, 0., 1.);
+    FillHist(this_region+"/Lepton_"+this_itoa+"_MiniRelIso_"+this_region, lep->MiniRelIso(), weight, 100, 0., 1.);
 
-    JSFillHist(this_region, "Lepton_"+this_itoa+"_dXY_"+this_region, fabs(lep->dXY()), weight, 500, 0., 0.05);
-    JSFillHist(this_region, "Lepton_"+this_itoa+"_dXYSig_"+this_region, fabs(lep->dXY()/lep->dXYerr()), weight, 100, 0., 10);
-    JSFillHist(this_region, "Lepton_"+this_itoa+"_dZ_"+this_region, fabs(lep->dZ()), weight, 500, 0., 0.5);
-    JSFillHist(this_region, "Lepton_"+this_itoa+"_dZSig_"+this_region, fabs(lep->dZ()/lep->dZerr()), weight, 100, 0., 10);
-    JSFillHist(this_region, "Lepton_"+this_itoa+"_IP3D_"+this_region, fabs(lep->IP3D()), weight, 500, 0., 0.5);
-    JSFillHist(this_region, "Lepton_"+this_itoa+"_IP3DSig_"+this_region, fabs(lep->IP3D()/lep->IP3Derr()), weight, 100, 0., 10);
+    FillHist(this_region+"/Lepton_"+this_itoa+"_dXY_"+this_region, fabs(lep->dXY()), weight, 500, 0., 0.05);
+    FillHist(this_region+"/Lepton_"+this_itoa+"_dXYSig_"+this_region, fabs(lep->dXY()/lep->dXYerr()), weight, 100, 0., 10);
+    FillHist(this_region+"/Lepton_"+this_itoa+"_dZ_"+this_region, fabs(lep->dZ()), weight, 500, 0., 0.5);
+    FillHist(this_region+"/Lepton_"+this_itoa+"_dZSig_"+this_region, fabs(lep->dZ()/lep->dZerr()), weight, 100, 0., 10);
+    FillHist(this_region+"/Lepton_"+this_itoa+"_IP3D_"+this_region, fabs(lep->IP3D()), weight, 500, 0., 0.5);
+    FillHist(this_region+"/Lepton_"+this_itoa+"_IP3DSig_"+this_region, fabs(lep->IP3D()/lep->IP3Derr()), weight, 100, 0., 10);
 
     if(lep->LeptonFlavour()==Lepton::ELECTRON){
       Electron *el = (Electron *)lep;
-      JSFillHist(this_region, "Lepton_"+this_itoa+"_MVANoIso_"+this_region, el->MVANoIso(), weight, 200, -1., 1.);
+      FillHist(this_region+"/Lepton_"+this_itoa+"_MVANoIso_"+this_region, el->MVANoIso(), weight, 200, -1., 1.);
     }
     else if(lep->LeptonFlavour()==Lepton::MUON){
       Muon *mu = (Muon *)lep;
-      JSFillHist(this_region, "Lepton_"+this_itoa+"_Chi2_"+this_region, mu->Chi2(), weight, 500, 0., 50.);
-      JSFillHist(this_region, "Lepton_"+this_itoa+"_TrkRelIso_"+this_region, mu->TrkIso()/mu->TuneP4().Pt(), weight, 100, 0., 1.);
+      FillHist(this_region+"/Lepton_"+this_itoa+"_Chi2_"+this_region, mu->Chi2(), weight, 500, 0., 50.);
+      FillHist(this_region+"/Lepton_"+this_itoa+"_TrkRelIso_"+this_region, mu->TrkIso()/mu->TuneP4().Pt(), weight, 100, 0., 1.);
     }
     else{
       cout << "[AnalyzerCore::FillLeptonPlots] lepton flavour wrong.." << endl;
@@ -2116,22 +2116,22 @@ void AnalyzerCore::FillJetPlots(std::vector<Jet> jets, std::vector<FatJet> fatje
   for(unsigned int i=0; i<jets.size(); i++){
 
     TString this_itoa = TString::Itoa(i,10);
-    JSFillHist(this_region, "Jet_"+this_itoa+"_Pt_"+this_region, jets.at(i).Pt(), weight, 1000, 0., 1000.);
-    JSFillHist(this_region, "Jet_"+this_itoa+"_Eta_"+this_region, jets.at(i).Eta(), weight, 60, -3., 3.);
+    FillHist(this_region+"/Jet_"+this_itoa+"_Pt_"+this_region, jets.at(i).Pt(), weight, 1000, 0., 1000.);
+    FillHist(this_region+"/Jet_"+this_itoa+"_Eta_"+this_region, jets.at(i).Eta(), weight, 60, -3., 3.);
 
   }
 
   for(unsigned int i=0; i<fatjets.size(); i++){
 
     TString this_itoa = TString::Itoa(i,10);
-    JSFillHist(this_region, "FatJet_"+this_itoa+"_Pt_"+this_region, fatjets.at(i).Pt(), weight, 1000, 0., 1000.);
-    JSFillHist(this_region, "FatJet_"+this_itoa+"_Eta_"+this_region, fatjets.at(i).Eta(), weight, 60, -3., 3.);
-    JSFillHist(this_region, "FatJet_"+this_itoa+"_Mass_"+this_region, fatjets.at(i).M(), weight, 3000, 0., 3000.);
-    JSFillHist(this_region, "FatJet_"+this_itoa+"_SDMass_"+this_region, fatjets.at(i).SDMass(), weight, 3000, 0., 3000.);
-    JSFillHist(this_region, "FatJet_"+this_itoa+"_LSF_"+this_region, fatjets.at(i).LSF(), weight, 100, 0., 1.);
-    JSFillHist(this_region, "FatJet_"+this_itoa+"_PuppiTau21_"+this_region, fatjets.at(i).PuppiTau2()/fatjets.at(i).PuppiTau1(), weight, 100, 0., 1.);
-    JSFillHist(this_region, "FatJet_"+this_itoa+"_PuppiTau31_"+this_region, fatjets.at(i).PuppiTau3()/fatjets.at(i).PuppiTau1(), weight, 100, 0., 1.);
-    JSFillHist(this_region, "FatJet_"+this_itoa+"_PuppiTau32_"+this_region, fatjets.at(i).PuppiTau3()/fatjets.at(i).PuppiTau2(), weight, 100, 0., 1.);
+    FillHist(this_region+"/FatJet_"+this_itoa+"_Pt_"+this_region, fatjets.at(i).Pt(), weight, 1000, 0., 1000.);
+    FillHist(this_region+"/FatJet_"+this_itoa+"_Eta_"+this_region, fatjets.at(i).Eta(), weight, 60, -3., 3.);
+    FillHist(this_region+"/FatJet_"+this_itoa+"_Mass_"+this_region, fatjets.at(i).M(), weight, 3000, 0., 3000.);
+    FillHist(this_region+"/FatJet_"+this_itoa+"_SDMass_"+this_region, fatjets.at(i).SDMass(), weight, 3000, 0., 3000.);
+    FillHist(this_region+"/FatJet_"+this_itoa+"_LSF_"+this_region, fatjets.at(i).LSF(), weight, 100, 0., 1.);
+    FillHist(this_region+"/FatJet_"+this_itoa+"_PuppiTau21_"+this_region, fatjets.at(i).PuppiTau2()/fatjets.at(i).PuppiTau1(), weight, 100, 0., 1.);
+    FillHist(this_region+"/FatJet_"+this_itoa+"_PuppiTau31_"+this_region, fatjets.at(i).PuppiTau3()/fatjets.at(i).PuppiTau1(), weight, 100, 0., 1.);
+    FillHist(this_region+"/FatJet_"+this_itoa+"_PuppiTau32_"+this_region, fatjets.at(i).PuppiTau3()/fatjets.at(i).PuppiTau2(), weight, 100, 0., 1.);
   }
 
 }

--- a/Analyzers/src/ExampleRun.C
+++ b/Analyzers/src/ExampleRun.C
@@ -188,7 +188,7 @@ void ExampleRun::executeEvent(){
     //cout << "[ExampleRun::executeEvent] PDF reweight for error set (NErrorSet = "<<pdfReweight->NErrorSet<< ") :" << endl;
     for(int i=0; i<pdfReweight->NErrorSet; i++){
       //cout << "[ExampleRun::executeEvent]   " << GetPDFReweight(i) << endl;
-      JSFillHist("NewPDF_PDFErrorSet", "PDFReweight_Member_"+TString::Itoa(i,10), GetPDFReweight(i), 1., 2000, 0.90, 1.10);
+      FillHist("NewPDF_PDFErrorSet/PDFReweight_Member_"+TString::Itoa(i,10), GetPDFReweight(i), 1., 2000, 0.90, 1.10);
     }
   }
 
@@ -206,15 +206,15 @@ void ExampleRun::executeEvent(){
     //==== 1) PDF Error
     //==== Obtain RMS of the distribution later
     for(unsigned int i=0; i<PDFWeights_Error->size(); i++){
-      JSFillHist("XSecError", "MET_PDFError_"+TString::Itoa(i,10), MET, PDFWeights_Error->at(i), 200, 0., 200.);
+      FillHist("XSecError/MET_PDFError_"+TString::Itoa(i,10), MET, PDFWeights_Error->at(i), 200, 0., 200.);
     }
 
     //==== 2) PDF AlphaS
     //==== Look for PDF4LHC paper..
     //==== https://arxiv.org/abs/1510.03865
     if(PDFWeights_AlphaS->size()==2){
-      JSFillHist("XSecError", "MET_PDFAlphaS_Down", MET, PDFWeights_AlphaS->at(0), 200, 0., 200.);
-      JSFillHist("XSecError", "MET_PDFAlphaS_Up", MET, PDFWeights_AlphaS->at(1), 200, 0., 200.);
+      FillHist("XSecError/MET_PDFAlphaS_Down", MET, PDFWeights_AlphaS->at(0), 200, 0., 200.);
+      FillHist("XSecError/MET_PDFAlphaS_Up", MET, PDFWeights_AlphaS->at(1), 200, 0., 200.);
     }
 
     //==== 3) Scale
@@ -223,7 +223,7 @@ void ExampleRun::executeEvent(){
       //==== i=5 and 7 are unphysical
       if(i==5) continue;
       if(i==7) continue;
-      JSFillHist("XSecError", "MET_Scale_"+TString::Itoa(i,10), MET, PDFWeights_Scale->at(i), 200, 0., 200.);
+      FillHist("XSecError/MET_Scale_"+TString::Itoa(i,10), MET, PDFWeights_Scale->at(i), 200, 0., 200.);
     }
 
   }
@@ -236,7 +236,7 @@ void ExampleRun::executeEventFromParameter(AnalyzerParameter param){
   //==== No Cut
   //=============
 
-  JSFillHist(param.Name, "NoCut_"+param.Name, 0., 1., 1, 0., 1.);
+  FillHist(param.Name+"/NoCut_"+param.Name, 0., 1., 1, 0., 1.);
 
   //========================
   //==== MET Filter
@@ -401,7 +401,7 @@ void ExampleRun::executeEventFromParameter(AnalyzerParameter param){
   //==== Now fill histograms
   //==========================
 
-  JSFillHist(param.Name, "ZCand_Mass_"+param.Name, ZCand.M(), weight, 40, 70., 110.);
+  FillHist(param.Name+"/ZCand_Mass_"+param.Name, ZCand.M(), weight, 40, 70., 110.);
 
 }
 

--- a/Analyzers/src/SKFlatValidation.C
+++ b/Analyzers/src/SKFlatValidation.C
@@ -403,42 +403,42 @@ void SKFlatValidation::executeEventFromParameter(AnalyzerParameter param){
 
       if(it_map->second){
 
-        JSFillHist(this_region, "NEvent_"+this_region, 0., weight, 1, 0., 1.);
+        FillHist(this_region+"/NEvent_"+this_region, 0., weight, 1, 0., 1.);
 
-        JSFillHist(this_region, "nPileUp_"+this_region, nPileUp, weight, 200., 0., 200.);
-        JSFillHist(this_region, "nPV_"+this_region, nPV, weight, 200., 0., 200.);
-        JSFillHist(this_region, "nPUForReweight_"+this_region, nPUForReweight, weight, 200., 0., 200.);
+        FillHist(this_region+"/nPileUp_"+this_region, nPileUp, weight, 200., 0., 200.);
+        FillHist(this_region+"/nPV_"+this_region, nPV, weight, 200., 0., 200.);
+        FillHist(this_region+"/nPUForReweight_"+this_region, nPUForReweight, weight, 200., 0., 200.);
 
-        JSFillHist(this_region, "MET_"+this_region, METv.Pt(), weight, 500, 0., 500.);
-        JSFillHist(this_region, "METphi_"+this_region, METv.Phi(), weight, 60, -3., 3.);
+        FillHist(this_region+"/MET_"+this_region, METv.Pt(), weight, 500, 0., 500.);
+        FillHist(this_region+"/METphi_"+this_region, METv.Phi(), weight, 60, -3., 3.);
 
-        JSFillHist(this_region, "HT_"+this_region, HT, weight, 1000, 0., 1000.);
+        FillHist(this_region+"/HT_"+this_region, HT, weight, 1000, 0., 1000.);
 
-        JSFillHist(this_region, "Jet_Size_"+this_region, myjets.size(), weight, 10, 0., 10.);
-        JSFillHist(this_region, "NBJets_NoSF_"+this_region, NBJets_NoSF, weight, 10, 0., 10.);
-        JSFillHist(this_region, "NBJets_WithSF_1a_"+this_region, NBJets_NoSF, weight*btagWeight_1a, 10, 0., 10.);
-        JSFillHist(this_region, "NBJets_WithSF_1d_"+this_region, NBJets_NoSF, weight*btagWeight_1d, 10, 0., 10.);
-        JSFillHist(this_region, "NBJets_WithSF_2a_"+this_region, NBJets_WithSF_2a, weight, 10, 0., 10.);
+        FillHist(this_region+"/Jet_Size_"+this_region, myjets.size(), weight, 10, 0., 10.);
+        FillHist(this_region+"/NBJets_NoSF_"+this_region, NBJets_NoSF, weight, 10, 0., 10.);
+        FillHist(this_region+"/NBJets_WithSF_1a_"+this_region, NBJets_NoSF, weight*btagWeight_1a, 10, 0., 10.);
+        FillHist(this_region+"/NBJets_WithSF_1d_"+this_region, NBJets_NoSF, weight*btagWeight_1d, 10, 0., 10.);
+        FillHist(this_region+"/NBJets_WithSF_2a_"+this_region, NBJets_WithSF_2a, weight, 10, 0., 10.);
 
         for(unsigned int ij=0; ij<myjets.size(); ij++){
           TString this_itoa = TString::Itoa(ij,10);
 
           double this_discr = myjets.at(ij).GetTaggerResult(JetTagging::DeepCSV);
-          JSFillHist(this_region, "Jet_"+this_itoa+"_DeepCSV_"+this_region, this_discr, weight, 120, 0., 1.2);
-          JSFillHist(this_region, "Jet_"+this_itoa+"_DeepCSV_Scaled_"+this_region, this_discr, weight*btagWeight_1d, 120, 0., 1.2);
+          FillHist(this_region+"/Jet_"+this_itoa+"_DeepCSV_"+this_region, this_discr, weight, 120, 0., 1.2);
+          FillHist(this_region+"/Jet_"+this_itoa+"_DeepCSV_Scaled_"+this_region, this_discr, weight*btagWeight_1d, 120, 0., 1.2);
         }
 
         FillLeptonPlots(leps, this_region, weight);
 
         if(n_lepton==1){
-          JSFillHist(this_region, "MT_"+this_region, this_MT, weight, 500, 0., 500.);
+          FillHist(this_region+"/MT_"+this_region, this_MT, weight, 500, 0., 500.);
         }
 
         if(n_lepton>=2){
 
-          JSFillHist(this_region, "ZCand_Mass_"+this_region, Z.M(), weight, 7000, 0., 7000.);
-          JSFillHist(this_region, "ZCand_Pt_"+this_region, Z.Pt(), weight, 500, 0., 500.);
-          JSFillHist(this_region, "ZCand_Eta_"+this_region, Z.Eta(), weight, 60, -3., 3.);
+          FillHist(this_region+"/ZCand_Mass_"+this_region, Z.M(), weight, 7000, 0., 7000.);
+          FillHist(this_region+"/ZCand_Pt_"+this_region, Z.Pt(), weight, 500, 0., 500.);
+          FillHist(this_region+"/ZCand_Eta_"+this_region, Z.Eta(), weight, 60, -3., 3.);
 
         }
 


### PR DESCRIPTION
JSFillHist is a function which takes a form of
JSFillHist(Directory name, histogram name, ~~), and it uses 

`std::map< TString, std::map<TString, TH1D*> > JSmaphist_TH1D`

which is a map of a map.

@jalmond reported that it becomes very slow when we have many histograms.

Thanks to @sansan9401 , FillHist can do the exact same thing, and has more features : 

`FillHist("dirA/dirB/dirC/histname", ~)`

I now recommend the users use FillHist, and avoid JSFillHist.

For now I keep this function, but I will remove them in the future.

I replaced JSFillHist from example and SKFlatValidation codes in this commit.

AnalyzerCore::FillLeptonPlots and AnalyzerCore::FillJetPlots are also modified.