### PR TITLE
v200821 - update shared gen-matching code

### DIFF
--- a/Analyzers/include/AnalyzerCore.h
+++ b/Analyzers/include/AnalyzerCore.h
@@ -186,7 +186,10 @@ public:
   vector<int> TrackGenSelfHistory(const Gen& me, const std::vector<Gen>& gens);
   bool IsFromHadron(const Gen& me, const std::vector<Gen>& gens);
   int GetLeptonType(const Lepton& lep, const std::vector<Gen>& gens);
+  int GetLeptonType_Public(int TruthIdx, const std::vector<Gen>& TruthColl);
   int GetGenPhotonType(const Gen& genph, const std::vector<Gen>& gens);
+  bool IsFinalPhotonSt23_Public(const std::vector<Gen>& TruthColl);
+  int  GetPrElType_InSameSCRange_Public(int TruthIdx, const std::vector<Gen>& TruthColl);
   bool IsSignalPID(int pid);
 
   //==== Plotting


### PR DESCRIPTION
Update of genmatching code used by SNU students.

Major changes:
1) FinalPhotonSt23 in the CatAnalyzer code is recovered here.
In case of external conversion, checking this kinds of photons should not be ignored. In principle, final state photon should be status-1, but I put this function in the CatAnalyzer code as I observed there are many of such cases. I believe this is due to skimming generator history between pythia and MiniAOD. I put a link to explicit example of this case in this shared link: https://cernbox.cern.ch/index.php/s/yQwJxnWMp7S9Tji

2) external conversion matching condition reoptimized.
Previous dR and dPtRel cuts are optimized for electron with PT>25. Now the cuts are reoptimized for PT>10. dR cut is sill valid for PT[10-25] but dPtRel cut is changed from 0.2 to 0.5

3) consideration of soft radiation of electron and SC merging.
Due to the small mass, electrons often radiate photon that result in a electron pair. When matching reco-electron with gen-electron with closest dR, sometimes these very soft internal conversion electron is matched instead of nearby mother prompt electron. But electron reconstruction algorithm takes account of this feature of electron. Supercluster is reconstructed to gather all soft radiation from electron to get ~pre-FSR electron momentum, and select best track responsible to the SC energy. Therefore it is reasonable to match to pre-FSR prompt electron instead of closest and very soft electron (internal) conversion electron. So if internal conversion electron is within the range of SC-merging range from status-1,2,3 lepton, then the matched status is assigned 1-3 instead of 4-5(internal conversion)