### PR TITLE
fixbug for 2016 DeepJet Tight

### DIFF
--- a/AnalyzerTools/src/BTagCalibrationStandalone.C
+++ b/AnalyzerTools/src/BTagCalibrationStandalone.C
@@ -40,12 +40,18 @@ BTagEntry::BTagEntry(const std::string &csvLine)
   std::stringstream buff(csvLine);
   std::vector<std::string> vec;
   std::string token;
+  std::string word="";
   while (std::getline(buff, token, ","[0])) {
-    token = BTagEntry::trimStr(token);
-    if (token.empty()) {
+    word += BTagEntry::trimStr(token);
+    if (word.empty()) {
       continue;
     }
-    vec.push_back(token);
+    if(std::count(word.begin(),word.end(),'(')-std::count(word.begin(),word.end(),')')!=0){
+      word+=",";
+      continue;
+    }
+    vec.push_back(word);
+    word="";
   }
   if (vec.size() != 11) {
 std::cerr << "ERROR in BTagCalibration: "


### PR DESCRIPTION
Related to #110 

There are *pow(x,1.5)* functions in [the csv file for 2016 DeepJet Tight](https://github.com/CMSSNU/SKFlatAnalyzer/blob/e2952427a5b789e79a49ea9e8a820d8b45799983/data/Run2UltraLegacy_v2/2016preVFP/BTag/wp_deepJet_106XUL16preVFP_v2.csv#L16). We need to distinguish this comma here from the csv delimiter (also comma) when read the csv files.