### PR TITLE
for gluster bug during remove-brick

### DIFF
--- a/python/SKFlat.py
+++ b/python/SKFlat.py
@@ -495,6 +495,8 @@ void {2}(){{
         out.write('    "'+flag+'",\n')
       out.write('  };\n')
 
+    for it_dir in set([os.path.dirname(lines_files[it_file].strip('\n')) for it_file in FileRanges[it_job]]):
+      out.write('  system("ls {}");\n'.format(it_dir))
     for it_file in FileRanges[it_job]:
       thisfilename = lines_files[it_file].strip('\n')
       out.write('  if(!m.AddFile("'+thisfilename+'")) exit(EIO);\n')


### PR DESCRIPTION
* @youngwan-kim reports that he cannot access some files in gv0. I believe this is a bug during *remove-brick* procedure of the glusterfs. 
* I found that it is fixed when executing `ls` on its mother directory. So, I added some lines to do `ls` before read files.