### PR TITLE
Revert "for gluster bug during remove-brick"

### DIFF
--- a/python/SKFlat.py
+++ b/python/SKFlat.py
@@ -495,8 +495,6 @@ void {2}(){{
         out.write('    "'+flag+'",\n')
       out.write('  };\n')
 
-    for it_dir in set([os.path.dirname(lines_files[it_file].strip('\n')) for it_file in FileRanges[it_job]]):
-      out.write('  system("ls {}");\n'.format(it_dir))
     for it_file in FileRanges[it_job]:
       thisfilename = lines_files[it_file].strip('\n')
       out.write('  if(!m.AddFile("'+thisfilename+'")) exit(EIO);\n')


### PR DESCRIPTION
Reverts CMSSNU/SKFlatAnalyzer#114

@jbhyun reports that this solution (#114) is not work for long jobs as the files disappear again after some time.
The problem is that gluster looks up a file over sub-volumes with the hash table using the file name. It is usually fine, but the hash table may be not correct during removing its sub-volume. As you know, I removing and adding sub-volumes for the transition from RAID5 to RAID6.

Now, I turned off one of the gluster option (*cluster.lookup-optimize*) so that gluster searches all the sub-volumes. This resolved the issue and this commit is not needed anymore.
