### PR TITLE
fixbug: ROOT 6.22.08 -> 6.22.06 due to very slow hadd

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -11,7 +11,7 @@ export DATA_DIR=$SKFlat_WD/data/$SKFlatV
 export CMS_PATH=/cvmfs/cms.cern.ch
 source $CMS_PATH/cmsset_default.sh
 export SCRAM_ARCH=slc7_amd64_gcc900
-export cmsswrel='cmssw/CMSSW_11_3_0'
+export cmsswrel='cmssw/CMSSW_11_2_5'
 cd /cvmfs/cms.cern.ch/$SCRAM_ARCH/cms/$cmsswrel/src
 echo "@@@@ SCRAM_ARCH = "$SCRAM_ARCH
 echo "@@@@ cmsswrel = "$cmsswrel


### PR DESCRIPTION
* ROOT 6.22.08 has a bug in `hadd`. See https://github.com/root-project/root/issues/9939
* CMSSW_11_3_0 (ROOT 6.22.08) -> CMSSW_11_2_5 (ROOT 6.22.06)

* You need to do `make distclean` after merging