### PR TITLE
Use root in CMSSW_15_0_1, default for NanoV15

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -10,8 +10,8 @@ export DATA_DIR=$SKFlat_WD/data/$SKFlatV
 #### use cvmfs for root ####
 export CMS_PATH=/cvmfs/cms.cern.ch
 source $CMS_PATH/cmsset_default.sh
-export SCRAM_ARCH=slc7_amd64_gcc900
-export cmsswrel='cmssw/CMSSW_11_2_5'
+export SCRAM_ARCH=slc9_amd64_gcc12
+export cmsswrel='cmssw/CMSSW_15_0_1'
 cd /cvmfs/cms.cern.ch/$SCRAM_ARCH/cms/$cmsswrel/src
 echo "@@@@ SCRAM_ARCH = "$SCRAM_ARCH
 echo "@@@@ cmsswrel = "$cmsswrel
@@ -57,6 +57,7 @@ export PATH=${MYBIN}:${PYTHONDIR}:${PATH}
 
 export ROOT_INCLUDE_PATH=$ROOT_INCLUDE_PATH:$SKFlat_WD/DataFormats/include/:$SKFlat_WD/AnalyzerTools/include/:$SKFlat_WD/Analyzers/include/
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SKFlat_LIB_PATH
+export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/bin/python2.7:$LD_LIBRARY_PATH
 
 source $SKFlat_WD/bin/BashColorSets.sh
 


### PR DESCRIPTION
Tested histogram yields in ExampleRun (by @Chihwan-An)
—————————————————————
histogram : ZCand_Mass_POGMedium_Central 
—————————————————————-
tamsa2 : 
slc7_amd64_gcc900/CMSSW_11_2_5 ->  824926.96
gamsa : 
el9_amd64_gcc11 / CMSSW_13_0_10 -> 824926.96
el9_amd64_gcc12 /CMSSW_15_0_1    -> 824926.96

—————————————————————
histogram : ZCand_Mass_POGTight_Central 
—————————————————————-
tamsa2 : 
slc7_amd64_gcc900/CMSSW_11_2_5 ->  800739.04
gamsa : 
el9_amd64_gcc11 / CMSSW_13_0_10 -> 800739.04
el9_amd64_gcc12 /CMSSW_15_0_1    -> 800739.04